### PR TITLE
Added a space after repo

### DIFF
--- a/frontend/src/components/regions/AgileBoard/AgileCard/Presentation.js
+++ b/frontend/src/components/regions/AgileBoard/AgileCard/Presentation.js
@@ -150,7 +150,7 @@ export default ({
         <Typography variant="caption"> [card id:{card.id}]</Typography>
 
         <Typography variant="h6" component="h2">
-          {card.title} 
+          {card.title}
         </Typography>
        
         {/* {card.flavourNames.map((flavour) => (


### PR DESCRIPTION
Related issues: [please specify]

## Description:

I added just a space in between repo and the card id for consistency as seen in the topic and card id

FYI: There's no ticket associated with this as it is very tiny thing

What are you up to? Fill us in :)

## Screenshots/videos

Before :
you will note that there's no space between the repo and the square bracket

<img width="516" alt="Screenshot 2021-10-22 at 03 12 38" src="https://user-images.githubusercontent.com/35369692/138377700-c891c920-e641-491c-a7ed-579d458b9f99.png">

After:
<img width="176" alt="Screenshot 2021-10-22 at 03 12 56" src="https://user-images.githubusercontent.com/35369692/138377760-ad17f354-dd6d-42ec-a20a-9a25f1a6f332.png">



<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
