### PR TITLE
Polish for user stats per week/231

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,4 +1,4 @@
-from curriculum_tracking.serializers import UserStatsPerWeekSerializer
+from curriculum_tracking.serializers import UserDetailedStatsSerializer
 from . import models
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -176,7 +176,7 @@ class UserViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["GET"],
-        serializer_class=UserStatsPerWeekSerializer,
+        serializer_class=UserDetailedStatsSerializer,
         permission_classes=[
             IsAdminUser
             | core_permissions.IsMyUser
@@ -190,7 +190,7 @@ class UserViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
             user_object = self.get_object()
-            return Response(UserStatsPerWeekSerializer(user_object).data)
+            return Response(UserDetailedStatsSerializer(user_object).data)
         else:
             return Response(serializer.errors, status="BAD_REQUEST")
 

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -439,9 +439,8 @@ class UserDetailedStatsSerializer(serializers.ModelSerializer):
     def get_cards_currently_blocked_as_assignee(self, user):
 
         cards_currently_blocked_as_assignee = models.AgileCard.objects.filter(
-            status=models.AgileCard.BLOCKED, assignees=user.id
+            Q(status=models.AgileCard.BLOCKED) & Q(assignees=user.id)
         ).count()
-
         return cards_currently_blocked_as_assignee
 
     def get_cards_completed_last_7_days_as_assignee(self, user):

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -338,7 +338,7 @@ class WorkshopAttendanceSerializer(serializers.ModelSerializer):
         ]
 
 
-class UserStatsPerWeekSerializer(serializers.ModelSerializer):
+class UserDetailedStatsSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.User
         fields = [
@@ -347,6 +347,7 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
             "cards_in_review_column_as_assignee",
             "cards_in_review_feedback_column_as_assignee",
             "cards_in_progress_column_as_assignee",
+            "cards_currently_blocked_as_assignee",
             "cards_completed_last_7_days_as_assignee",
             "cards_started_last_7_days_as_assignee",
             "total_tilde_reviews_done",
@@ -369,6 +370,11 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
     cards_in_progress_column_as_assignee = serializers.SerializerMethodField(
         "get_cards_in_progress_column_as_assignee"
     )
+
+    cards_currently_blocked_as_assignee = serializers.SerializerMethodField(
+        "get_cards_currently_blocked_as_assignee"
+    )
+
     cards_completed_last_7_days_as_assignee = serializers.SerializerMethodField(
         "get_cards_completed_last_7_days_as_assignee"
     )
@@ -429,6 +435,14 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         ).count()
 
         return cards_in_progress_column_as_assignee
+
+    def get_cards_currently_blocked_as_assignee(self, user):
+
+        cards_currently_blocked_as_assignee = models.AgileCard.objects.filter(
+            status=models.AgileCard.BLOCKED, assignees=user.id
+        ).count()
+
+        return cards_currently_blocked_as_assignee
 
     def get_cards_completed_last_7_days_as_assignee(self, user):
 

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -444,14 +444,15 @@ class UserDetailedStatsSerializer(serializers.ModelSerializer):
     def get_cards_currently_blocked_as_assignee(self, user):
 
         cards_currently_blocked_as_assignee = models.AgileCard.objects.filter(
-            Q(status=models.AgileCard.BLOCKED) & Q(assignees=user.id)
+            status=models.AgileCard.BLOCKED, assignees=user.id
         ).count()
+
         return cards_currently_blocked_as_assignee
 
     def get_cards_ready_as_assignee(self, user):
 
         cards_currently_ready_as_assignee = models.AgileCard.objects.filter(
-            Q(status=models.AgileCard.READY) & Q(assignees=user.id)
+            status=models.AgileCard.READY, assignees=user.id
         ).count()
 
         return cards_currently_ready_as_assignee

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -348,6 +348,7 @@ class UserDetailedStatsSerializer(serializers.ModelSerializer):
             "cards_in_review_feedback_column_as_assignee",
             "cards_in_progress_column_as_assignee",
             "cards_currently_blocked_as_assignee",
+            "cards_ready_as_assignee"
             "cards_completed_last_7_days_as_assignee",
             "cards_started_last_7_days_as_assignee",
             "total_tilde_reviews_done",
@@ -373,6 +374,10 @@ class UserDetailedStatsSerializer(serializers.ModelSerializer):
 
     cards_currently_blocked_as_assignee = serializers.SerializerMethodField(
         "get_cards_currently_blocked_as_assignee"
+    )
+
+    cards_ready_as_assignee = serializers.SerializerMethodField(
+        "get_cards_ready_as_assignee"
     )
 
     cards_completed_last_7_days_as_assignee = serializers.SerializerMethodField(
@@ -442,6 +447,15 @@ class UserDetailedStatsSerializer(serializers.ModelSerializer):
             Q(status=models.AgileCard.BLOCKED) & Q(assignees=user.id)
         ).count()
         return cards_currently_blocked_as_assignee
+
+    def get_cards_ready_as_assignee(self, user):
+
+        cards_currently_ready_as_assignee = models.AgileCard.objects.filter(
+            Q(status=models.AgileCard.READY) & Q(assignees=user.id)
+        ).count()
+
+        return cards_currently_ready_as_assignee
+
 
     def get_cards_completed_last_7_days_as_assignee(self, user):
 

--- a/backend/curriculum_tracking/tests/test_UserDetailedStatsAPI.py
+++ b/backend/curriculum_tracking/tests/test_UserDetailedStatsAPI.py
@@ -52,6 +52,7 @@ class TestingForUserDetailedStatsAPI(TestCase):
             updated_at=self.today,
         )
         self.pull_request.save()
+        self.serializer = UserDetailedStatsSerializer()
 
     def test_one_card_in_progress_before_any_reviews(self):
 
@@ -215,7 +216,7 @@ class TestingForUserDetailedStatsAPI(TestCase):
 
     def test_get_tilde_cards_reviewed_in_last_7_days(self):
         user = UserFactory()
-        serializer = UserDetailedStatsSerializer()
+        serializer = self.serializer
 
         # no reviews done yet
         count = serializer.get_tilde_cards_reviewed_in_last_7_days(user)
@@ -271,18 +272,35 @@ class TestingForUserDetailedStatsAPI(TestCase):
         count = serializer.get_tilde_cards_reviewed_in_last_7_days(user)
         self.assertEqual(count, 2)
 
-    def test_no_cards_currently_blocked(self):
+    def test_zero_cards_currently_blocked(self):
         user = UserFactory()
-        serializer = UserDetailedStatsSerializer()
+        serializer = self.serializer
 
         count = serializer.get_cards_currently_blocked_as_assignee(user)
         self.assertEqual(count, 0)
 
     def test_one_card_currently_blocked(self):
 
-        serializer = UserDetailedStatsSerializer()
+        serializer = self.serializer
         card = factories.AgileCardFactory(status=AgileCard.BLOCKED)
         user = card.assignees.first()
 
         count = serializer.get_cards_currently_blocked_as_assignee(user)
         self.assertEqual(count, 1)
+
+    def test_one_card_currently_on_ready_status(self):
+
+        card = factories.AgileCardFactory(status=AgileCard.READY)
+        user = card.assignees.first()
+
+        count = self.serializer.get_cards_ready_as_assignee(user)
+        self.assertEqual(count, 1)
+
+    def test_zero_cards_currently_on_ready_status(self):
+
+        card = self.card_1
+        user = card.assignees.first()
+
+        count = self.serializer.get_cards_ready_as_assignee(user)
+        self.assertEqual(count, 0)
+


### PR DESCRIPTION
Related issues: [please specify]

1. I've made some changes to the UserStatsPerWeek Serializer, it is now called "UserDetailedStatsSerializer".
2. I've added extra functionality to UserDetailedStatsSerializer, functionality such as how many cards are currently blocked, and how many cards are ready to be started.
3. I've added some tests for the new functionality, the tests live inside "test_UserDetailedStatsAPI.py" which is located in backend/curriculum_tracking/tests.  The test file has already been renamed in accordance with the renaming of the serializer, hence why the new file name is "test_UserDetailedStatsAPI".

What are you up to? Fill us in :)

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
