### PR TITLE
Tilde weekly reviews bug

### DIFF
--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -457,10 +457,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         )
 
         return project_reviews_done_to_date + topic_reviews_done_to_date
-        # if tilde_project_reviews_done_to_date == None:
-        #     return tilde_topic_reviews_done_to_date
-        # else:
-        #     return tilde_project_reviews_done_to_date
 
     def get_tilde_cards_reviewed_in_last_7_days(self, user):
         tilde_project_reviews_done_in_past_seven_days = (

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -399,7 +399,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
     )
 
     def get_cards_in_complete_column_as_assignee(self, user):
-
         cards_in_completed_column_as_assignee_amount = models.AgileCard.objects.filter(
             status=models.AgileCard.COMPLETE, assignees=user.id
         ).count()
@@ -407,7 +406,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_in_completed_column_as_assignee_amount
 
     def get_cards_in_review_column_as_assignee(self, user):
-
         cards_in_review_column_as_assignee_amount = models.AgileCard.objects.filter(
             status=models.AgileCard.IN_REVIEW, assignees=user.id
         ).count()
@@ -415,7 +413,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_in_review_column_as_assignee_amount
 
     def get_cards_in_review_feedback_column_as_assignee(self, user):
-
         cards_in_review_feedback_column_as_assignee_amount = (
             models.AgileCard.objects.filter(
                 status=models.AgileCard.REVIEW_FEEDBACK, assignees=user.id
@@ -425,7 +422,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_in_review_feedback_column_as_assignee_amount
 
     def get_cards_in_progress_column_as_assignee(self, user):
-
         cards_in_progress_column_as_assignee = models.AgileCard.objects.filter(
             status=models.AgileCard.IN_PROGRESS, assignees=user.id
         ).count()
@@ -433,7 +429,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_in_progress_column_as_assignee
 
     def get_cards_completed_last_7_days_as_assignee(self, user):
-
         cards_completed_past_seven_days = models.AgileCard.objects.filter(
             status=models.AgileCard.COMPLETE,
             assignees=user.id,
@@ -443,7 +438,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_completed_past_seven_days
 
     def get_cards_started_last_7_days_as_assignee(self, user):
-
         cards_started_past_seven_days = models.AgileCard.objects.filter(
             assignees=user.id,
             recruit_project__start_time__gte=timezone.now() - timedelta(days=7),
@@ -452,24 +446,23 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return cards_started_past_seven_days
 
     def get_total_tilde_reviews_done(self, user):
-
-        tilde_project_reviews_done_to_date = (
+        project_reviews_done_to_date = (
             models.RecruitProjectReview.objects.filter(reviewer_user_id=user.id)
             .all()
             .count()
         )
 
-        tilde_topic_reviews_done_to_date = (
+        topic_reviews_done_to_date = (
             models.TopicReview.objects.filter(reviewer_user_id=user.id).all().count()
         )
 
-        if tilde_project_reviews_done_to_date == None:
-            return tilde_topic_reviews_done_to_date
-        else:
-            return tilde_project_reviews_done_to_date
+        return project_reviews_done_to_date + topic_reviews_done_to_date
+        # if tilde_project_reviews_done_to_date == None:
+        #     return tilde_topic_reviews_done_to_date
+        # else:
+        #     return tilde_project_reviews_done_to_date
 
     def get_tilde_cards_reviewed_in_last_7_days(self, user):
-
         tilde_project_reviews_done_in_past_seven_days = (
             models.RecruitProjectReview.objects.filter(
                 reviewer_user_id=user.id,
@@ -496,8 +489,7 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         )
 
     def get_tilde_reviews_done_last_7_days(self, user):
-
-        tilde_project_reviews_done_in_past_seven_days = (
+        project_reviews_done_last_7_days = (
             models.RecruitProjectReview.objects.filter(
                 reviewer_user_id=user.id,
                 timestamp__gte=timezone.now() - timedelta(days=7),
@@ -506,7 +498,7 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
             .count()
         )
 
-        tilde_topic_reviews_done_in_past_seven_days = (
+        topic_reviews_done_last_7_days = (
             models.TopicReview.objects.filter(
                 reviewer_user_id=user.id,
                 timestamp__gte=timezone.now() - timedelta(days=7),
@@ -515,13 +507,9 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
             .count()
         )
 
-        if tilde_project_reviews_done_in_past_seven_days == None:
-            return tilde_topic_reviews_done_in_past_seven_days
-        else:
-            return tilde_project_reviews_done_in_past_seven_days
+        return project_reviews_done_last_7_days + topic_reviews_done_last_7_days
 
     def get_total_pr_reviews_done(self, user):
-
         pr_reviews_done_to_date = PullRequestReview.objects.filter(
             user=user
         ).count()
@@ -529,7 +517,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         return pr_reviews_done_to_date
 
     def get_pr_reviews_done_last_7_days(self, user):
-
         pr_reviews_done_past_seven_days = PullRequestReview.objects.filter(
             user=user, submitted_at__gte=timezone.now() - timedelta(days=7)
         ).count()
@@ -583,7 +570,6 @@ class TeamStatsSerializer(serializers.ModelSerializer):
         result = models.AgileCard.objects.filter(
             status=models.AgileCard.IN_REVIEW
         ).filter(assignees__in=users)
-        # breakpoint()
         return result.filter(~Q(content_item__tags__in=skip_tags))
 
     def get_oldest_open_pr_time(self, instance):

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -383,9 +383,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
     tilde_reviews_done_last_7_days = serializers.SerializerMethodField(
         "get_tilde_reviews_done_last_7_days"
     )
-    tilde_cards_reviewed_in_last_7_days = serializers.SerializerMethodField(
-        "get_tilde_cards_reviewed_in_last_7_days"
-    )
 
     # tilde_review_disagreements_in_last_7_days = serializers.SerializerMethodField(
     #     "get_tilde_review_disagreements_in_last_7_days"
@@ -457,32 +454,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         )
 
         return project_reviews_done_to_date + topic_reviews_done_to_date
-
-    def get_tilde_cards_reviewed_in_last_7_days(self, user):
-        tilde_project_reviews_done_in_past_seven_days = (
-            models.RecruitProjectReview.objects.filter(
-                reviewer_user_id=user.id,
-                timestamp__gte=timezone.now() - timedelta(days=7),
-            )
-        )
-
-        tilde_topic_reviews_done_in_past_seven_days = models.TopicReview.objects.filter(
-            reviewer_user_id=user.id,
-            timestamp__gte=timezone.now() - timedelta(days=7),
-        )
-
-        return (
-            models.AgileCard.objects.filter(
-                Q(
-                    recruit_project__project_reviews__in=tilde_project_reviews_done_in_past_seven_days
-                )
-                | Q(
-                    topic_progress__topic_reviews__in=tilde_topic_reviews_done_in_past_seven_days
-                )
-            )
-            .distinct()
-            .count()
-        )
 
     def get_tilde_reviews_done_last_7_days(self, user):
         project_reviews_done_last_7_days = (

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -383,6 +383,9 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
     tilde_reviews_done_last_7_days = serializers.SerializerMethodField(
         "get_tilde_reviews_done_last_7_days"
     )
+    tilde_cards_reviewed_in_last_7_days = serializers.SerializerMethodField(
+        "get_tilde_cards_reviewed_in_last_7_days"
+    )
 
     # tilde_review_disagreements_in_last_7_days = serializers.SerializerMethodField(
     #     "get_tilde_review_disagreements_in_last_7_days"
@@ -453,6 +456,33 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
         )
 
         return project_reviews_done_to_date + topic_reviews_done_to_date
+
+    def get_tilde_cards_reviewed_in_last_7_days(self, user):
+
+        tilde_project_reviews_done_in_past_seven_days = (
+            models.RecruitProjectReview.objects.filter(
+                reviewer_user_id=user.id,
+                timestamp__gte=timezone.now() - timedelta(days=7),
+            )
+        )
+
+        tilde_topic_reviews_done_in_past_seven_days = models.TopicReview.objects.filter(
+            reviewer_user_id=user.id,
+            timestamp__gte=timezone.now() - timedelta(days=7),
+        )
+
+        return (
+            models.AgileCard.objects.filter(
+                Q(
+                    recruit_project__project_reviews__in=tilde_project_reviews_done_in_past_seven_days
+                )
+                | Q(
+                    topic_progress__topic_reviews__in=tilde_topic_reviews_done_in_past_seven_days
+                )
+            )
+            .distinct()
+            .count()
+        )
 
     def get_tilde_reviews_done_last_7_days(self, user):
         project_reviews_done_last_7_days = (

--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -445,12 +445,11 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
     def get_total_tilde_reviews_done(self, user):
         project_reviews_done_to_date = (
             models.RecruitProjectReview.objects.filter(reviewer_user_id=user.id)
-            .all()
             .count()
         )
 
         topic_reviews_done_to_date = (
-            models.TopicReview.objects.filter(reviewer_user_id=user.id).all().count()
+            models.TopicReview.objects.filter(reviewer_user_id=user.id).count()
         )
 
         return project_reviews_done_to_date + topic_reviews_done_to_date
@@ -461,7 +460,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
                 reviewer_user_id=user.id,
                 timestamp__gte=timezone.now() - timedelta(days=7),
             )
-            .all()
             .count()
         )
 
@@ -470,7 +468,6 @@ class UserStatsPerWeekSerializer(serializers.ModelSerializer):
                 reviewer_user_id=user.id,
                 timestamp__gte=timezone.now() - timedelta(days=7),
             )
-            .all()
             .count()
         )
 

--- a/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
+++ b/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
@@ -228,4 +228,4 @@ class TestingForTheStatsAPI(TestCase):
         review5.save()
         AgileCardFactory(topic_progress=review5.topic_progress)
         count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
-        self.assertEqual(count, 2)
+        self.assertEqual(count, 3)

--- a/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
+++ b/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
@@ -173,10 +173,6 @@ class TestingForTheStatsAPI(TestCase):
     def test_no_tilde_reviews_done_in_last_7_days(self):
         user = UserFactory()
 
-        # no reviews done yet
-        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
-        self.assertEqual(count, 0)
-
         # add a review, but it's too old to count
         review = RecruitProjectReviewFactory(
             timestamp=self.two_weeks_ago, reviewer_user=user
@@ -197,8 +193,6 @@ class TestingForTheStatsAPI(TestCase):
         review1.timestamp = self.yesterday
         review1.save()
         AgileCardFactory(recruit_project=review1.recruit_project)
-        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
-        self.assertEqual(count, 1)
 
         # add another review, now the number of cards reviewed is 2
         review2 = RecruitProjectReviewFactory(
@@ -207,8 +201,6 @@ class TestingForTheStatsAPI(TestCase):
         review2.timestamp = self.yesterday
         review2.save()
         AgileCardFactory(recruit_project=review2.recruit_project)
-        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
-        self.assertEqual(count, 2)
 
         # add a topic review, now the number of cards reviewed is 3
         review3 = TopicReviewFactory(
@@ -237,8 +229,6 @@ class TestingForTheStatsAPI(TestCase):
         review1.timestamp = self.yesterday
         review1.save()
         AgileCardFactory(recruit_project=review1.recruit_project)
-        count = self.stats_serializer.get_total_tilde_reviews_done(user)
-        self.assertEqual(count, 1)
 
         # add really old review
         review2 = RecruitProjectReviewFactory(
@@ -247,8 +237,6 @@ class TestingForTheStatsAPI(TestCase):
         review2.timestamp = self.two_weeks_ago
         review2.save()
         AgileCardFactory(recruit_project=review2.recruit_project)
-        count = self.stats_serializer.get_total_tilde_reviews_done(user)
-        self.assertEqual(count, 2)
 
         # add a topic review, now we should have 3 reviews
         review3 = TopicReviewFactory(

--- a/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
+++ b/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
@@ -18,6 +18,7 @@ from curriculum_tracking.tests.factories import (
     ContentItemFactory,
     AgileCardFactory,
     RecruitProjectReviewFactory,
+    TopicReviewFactory
 )
 from django.utils import timezone
 from git_real.tests.factories import PullRequestReviewFactory
@@ -177,27 +178,22 @@ class TestingForTheStatsAPI(TestCase):
         self.assertEqual(count, 0)
 
         # add a review, but it's too old to count
-
         review1 = RecruitProjectReviewFactory(
             timestamp=self.two_weeks_ago, reviewer_user=user
         )
         review1.timestamp = self.two_weeks_ago
         review1.save()
         AgileCardFactory(recruit_project=review1.recruit_project)
-
         count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
         self.assertEqual(count, 0)
 
         # add a review within the right timeframe
-
         review2 = RecruitProjectReviewFactory(
             timestamp=self.yesterday, reviewer_user=user
         )
         review2.timestamp = self.yesterday
         review2.save()
         AgileCardFactory(recruit_project=review2.recruit_project)
-        # assert review.reviewer_user == user
-
         count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
         self.assertEqual(count, 1)
 
@@ -215,13 +211,21 @@ class TestingForTheStatsAPI(TestCase):
         self.assertEqual(count, 1)
 
         # add another review, now the number of cards reviewed is 2
-
         review4 = RecruitProjectReviewFactory(
             timestamp=self.yesterday, reviewer_user=user
         )
         review4.timestamp = self.yesterday
         review4.save()
         AgileCardFactory(recruit_project=review4.recruit_project)
+        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        self.assertEqual(count, 2)
 
+        # add a topic review, now the number of cards reviewed is 3
+        review5 = TopicReviewFactory(
+            timestamp=self.yesterday, reviewer_user=user
+        )
+        review5.timestamp = self.yesterday
+        review5.save()
+        AgileCardFactory(topic_progress=review5.topic_progress)
         count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
         self.assertEqual(count, 2)

--- a/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
+++ b/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
@@ -229,3 +229,40 @@ class TestingForTheStatsAPI(TestCase):
         AgileCardFactory(topic_progress=review5.topic_progress)
         count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
         self.assertEqual(count, 3)
+
+    def test_get_total_tilde_cards_reviewed_done(self):
+        user = UserFactory()
+
+        # no reviews done yet
+        count = self.stats_serializer.get_total_tilde_reviews_done(user)
+        self.assertEqual(count, 0)
+
+        # add a review
+        review2 = RecruitProjectReviewFactory(
+            timestamp=self.yesterday, reviewer_user=user
+        )
+        review2.timestamp = self.yesterday
+        review2.save()
+        AgileCardFactory(recruit_project=review2.recruit_project)
+        count = self.stats_serializer.get_total_tilde_reviews_done(user)
+        self.assertEqual(count, 1)
+
+        # add really old review
+        review1 = RecruitProjectReviewFactory(
+            timestamp=self.two_weeks_ago, reviewer_user=user
+        )
+        review1.timestamp = self.two_weeks_ago
+        review1.save()
+        AgileCardFactory(recruit_project=review1.recruit_project)
+        count = self.stats_serializer.get_total_tilde_reviews_done(user)
+        self.assertEqual(count, 2)
+
+        # add a topic review, now we should have 3 reviews
+        review5 = TopicReviewFactory(
+            timestamp=self.yesterday, reviewer_user=user
+        )
+        review5.timestamp = self.yesterday
+        review5.save()
+        AgileCardFactory(topic_progress=review5.topic_progress)
+        count = self.stats_serializer.get_total_tilde_reviews_done(user)
+        self.assertEqual(count, 3)

--- a/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
+++ b/backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py
@@ -170,11 +170,11 @@ class TestingForTheStatsAPI(TestCase):
         # of 2
         self.assertEqual(self.stats_serializer.get_pr_reviews_done_last_7_days(self.repo_card_one.assignees.first()), 2)
 
-    def test_get_tilde_cards_reviewed_in_last_7_days(self):
+    def test_get_tilde_reviews_done_last_7_days(self):
         user = UserFactory()
 
         # no reviews done yet
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 0)
 
         # add a review, but it's too old to count
@@ -184,7 +184,7 @@ class TestingForTheStatsAPI(TestCase):
         review1.timestamp = self.two_weeks_ago
         review1.save()
         AgileCardFactory(recruit_project=review1.recruit_project)
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 0)
 
         # add a review within the right timeframe
@@ -194,7 +194,7 @@ class TestingForTheStatsAPI(TestCase):
         review2.timestamp = self.yesterday
         review2.save()
         AgileCardFactory(recruit_project=review2.recruit_project)
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 1)
 
         # add another review on the same card, so now the number of cards reviewed is still 1
@@ -207,7 +207,7 @@ class TestingForTheStatsAPI(TestCase):
         review3.save()
         # AgileCardFactory(recruit_project=review3.recruit_project)
 
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 1)
 
         # add another review, now the number of cards reviewed is 2
@@ -217,7 +217,7 @@ class TestingForTheStatsAPI(TestCase):
         review4.timestamp = self.yesterday
         review4.save()
         AgileCardFactory(recruit_project=review4.recruit_project)
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 2)
 
         # add a topic review, now the number of cards reviewed is 3
@@ -227,7 +227,7 @@ class TestingForTheStatsAPI(TestCase):
         review5.timestamp = self.yesterday
         review5.save()
         AgileCardFactory(topic_progress=review5.topic_progress)
-        count = self.stats_serializer.get_tilde_cards_reviewed_in_last_7_days(user)
+        count = self.stats_serializer.get_tilde_reviews_done_last_7_days(user)
         self.assertEqual(count, 3)
 
     def test_get_total_tilde_cards_reviewed_done(self):


### PR DESCRIPTION
Related issues: #225 

## Description:

In **backend/curriculum_tracking/serializer.py**:
- Fixed logic for `get_tilde_reviews_done_last_7_days` and `get_total_tilde_reviews_done`.

In **backend/curriculum_tracking/tests/test_UserStatsPerWeekSerializer.py**:
- Added tests and cases to make sure functions count both project and topic reviews. For example if someone reviews a project and a topic within a week their reviews done should be 2 not 1.
- Replaced the rather long `test_get_tilde_reviews_done_last_7_days` with smaller specific tests; 
    1. `test_no_tilde_reviews_done_in_last_7_days`
    2. `test_multiple_tilde_reviews_done_in_last_7_days`
- Added tests for `UserStatsPerWeekSerializer.get_total_tilde_reviews_done`;
    1. `test_no_tilde_reviews_done`
    2. `test_multiple_tilde_reviews_done`

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
