### PR TITLE
Log card review request called/312

### DIFF
--- a/backend/curriculum_tracking/api_views.py
+++ b/backend/curriculum_tracking/api_views.py
@@ -356,8 +356,7 @@ class AgileCardViewset(viewsets.ModelViewSet):
             card.finish_topic()
         else:
             raise Http404
-        log_creators.log_card_review_requested(card, card.assignees) #**** what to use as actor_user here? 
-        #card.assignee is not right
+        log_creators.log_card_review_requested(card=card, actor_user=request.user) 
         # comes from here: def log_card_review_requested(card, actor_user) in activity_log_entry_creators.py
         card.refresh_from_db()
         assert (

--- a/backend/curriculum_tracking/api_views.py
+++ b/backend/curriculum_tracking/api_views.py
@@ -356,6 +356,9 @@ class AgileCardViewset(viewsets.ModelViewSet):
             card.finish_topic()
         else:
             raise Http404
+        log_creators.log_card_review_requested(card, card.assignees) #**** what to use as actor_user here? 
+        #card.assignee is not right
+        # comes from here: def log_card_review_requested(card, actor_user) in activity_log_entry_creators.py
         card.refresh_from_db()
         assert (
             card.status == models.AgileCard.IN_REVIEW

--- a/backend/curriculum_tracking/api_views.py
+++ b/backend/curriculum_tracking/api_views.py
@@ -350,14 +350,16 @@ class AgileCardViewset(viewsets.ModelViewSet):
     )
     def request_review(self, request, pk=None):
         card: models.AgileCard = self.get_object()
+
         if card.recruit_project:
             card.recruit_project.request_review(force_timestamp=timezone.now())
         elif card.topic_progress:
             card.finish_topic()
         else:
             raise Http404
-        log_creators.log_card_review_requested(card=card, actor_user=request.user) 
-        # comes from here: def log_card_review_requested(card, actor_user) in activity_log_entry_creators.py
+
+        log_creators.log_card_review_requested(card=card, actor_user=request.user)
+
         card.refresh_from_db()
         assert (
             card.status == models.AgileCard.IN_REVIEW

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -181,8 +181,8 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
         self.assertEqual(entry.object_2, None)
         self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
 
-    def test_review_requested_non_authorised_user(self):
-        actor_user = UserFactory(is_superuser=False)
+    def test_review_requested_non_assignee(self):
+        actor_user = UserFactory()
         content_item = factories.ProjectContentItemFactory(
             project_submission_type=ContentItem.LINK, template_repo=None
         )

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -119,14 +119,15 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
                 project_submission_type=ContentItem.LINK, template_repo=None
             )
         card = factories.AgileCardFactory(
-            status=AgileCard.READY,
+            status=AgileCard.READY, 
+
             
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
             content_item=content_item
             
         )
-        card.start_project()
-        self.login(actor_user)
+        self.login(actor_user) #do we not login first before starting project?
+        card.start_project() #means card is now IP
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"
         response = self.client.post(request_review_url)

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -30,7 +30,6 @@ class log_card_started_Tests(APITestCase, APITestCaseMixin):
         start_url = f"{self.get_instance_url(card.id)}start_project/"
         response = self.client.post(start_url)
         self.assertEqual(response.status_code, 200)
-        
 
         card.refresh_from_db()
 
@@ -110,106 +109,91 @@ class log_project_competence_review_done_Tests(APITestCase, APITestCaseMixin):
 
 
 class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
-    LIST_URL_NAME = "agilecard-list"  
+    LIST_URL_NAME = "agilecard-list"
     SUPPRESS_TEST_POST_TO_CREATE = True
     SUPPRESS_TEST_GET_LIST = True
 
     def test_review_requested_authorised_user(self):
         actor_user = UserFactory(is_superuser=True, is_staff=True)
-        content_item=factories.ProjectContentItemFactory(
-                project_submission_type=ContentItem.LINK, template_repo=None
-            )
-        card = factories.AgileCardFactory(
-            status=AgileCard.READY, 
-
-            
-            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
-            content_item=content_item
-            
-        )
-        self.login(actor_user) 
-        card.start_project() 
-        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
-
-        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
-        response = self.client.post(request_review_url)
-        
-        self.assertEqual(response.status_code, 200)
-
-        card.refresh_from_db()
-        self.assertEqual(card.status, AgileCard.IN_REVIEW)
-
-        # sanity check
-        self.assertEqual(card.assignees.count(), 1)
-        
-
-        self.assertEqual(LogEntry.objects.count(), 1)
-        entry = LogEntry.objects.first()
-
-        self.assertEqual(entry.actor_user, actor_user) 
-        self.assertEqual(entry.effected_user, card.assignees.first()) 
-        self.assertEqual(entry.object_1, card.recruit_project)
-        self.assertEqual(entry.object_2, None)
-        self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
-        
-
-    def test_review_requested_assignee(self):
-        
-        content_item=factories.ProjectContentItemFactory(
-                project_submission_type=ContentItem.LINK, template_repo=None
-            )
-        card = factories.AgileCardFactory(
-            status=AgileCard.READY, 
-
-            
-            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
-            content_item=content_item
-            
-        )
-        self.login(card.assignees.first()) 
-        card.start_project() 
-        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
-
-        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
-        response = self.client.post(request_review_url)
-        
-        self.assertEqual(response.status_code, 200)
-
-        card.refresh_from_db()
-        self.assertEqual(card.status, AgileCard.IN_REVIEW)
-
-        # sanity check
-        self.assertEqual(card.assignees.count(), 1)
-        
-
-        self.assertEqual(LogEntry.objects.count(), 1)
-        entry = LogEntry.objects.first()
-
-        self.assertEqual(entry.actor_user, card.assignees.first()) 
-        self.assertEqual(entry.effected_user, card.assignees.first()) 
-        self.assertEqual(entry.object_1, card.recruit_project)
-        self.assertEqual(entry.object_2, None)
-        self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
-
-
-    def test_review_requested_non_authorised_user(self):
-        actor_user = UserFactory(is_superuser=False)
-        content_item=factories.ProjectContentItemFactory(
+        content_item = factories.ProjectContentItemFactory(
             project_submission_type=ContentItem.LINK, template_repo=None
         )
         card = factories.AgileCardFactory(
-            status=AgileCard.IN_PROGRESS, 
+            status=AgileCard.READY,
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
-            content_item=content_item
-            )
-        self.login(actor_user) 
+            content_item=content_item,
+        )
+        self.login(actor_user)
+        card.start_project()
         self.assertEqual(card.status, AgileCard.IN_PROGRESS)
-    
+
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
+
+        # sanity check
+        self.assertEqual(card.assignees.count(), 1)
+
+        self.assertEqual(LogEntry.objects.count(), 1)
+        entry = LogEntry.objects.first()
+
+        self.assertEqual(entry.actor_user, actor_user)
+        self.assertEqual(entry.effected_user, card.assignees.first())
+        self.assertEqual(entry.object_1, card.recruit_project)
+        self.assertEqual(entry.object_2, None)
+        self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
+
+    def test_review_requested_assignee(self):
+
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(card.assignees.first())
+        card.start_project()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
+
+        # sanity check
+        self.assertEqual(card.assignees.count(), 1)
+
+        self.assertEqual(LogEntry.objects.count(), 1)
+        entry = LogEntry.objects.first()
+
+        self.assertEqual(entry.actor_user, card.assignees.first())
+        self.assertEqual(entry.effected_user, card.assignees.first())
+        self.assertEqual(entry.object_1, card.recruit_project)
+        self.assertEqual(entry.object_2, None)
+        self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
+
+    def test_review_requested_non_authorised_user(self):
+        actor_user = UserFactory(is_superuser=False)
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.IN_PROGRESS,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(actor_user)
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"
         response = self.client.post(request_review_url)
         self.assertEqual(response.status_code, 403)
-        
-        
-            
-

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -119,11 +119,12 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
             project_submission_type=ContentItem.LINK, template_repo=None
         )
         card = factories.AgileCardFactory(
-            status=AgileCard.IN_PROGRESS,
+            status=AgileCard.READY,
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
             content_item=content_item,
         )
         self.login(actor_user)
+        card.start_project()
         self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"
@@ -152,11 +153,12 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
             project_submission_type=ContentItem.LINK, template_repo=None
         )
         card = factories.AgileCardFactory(
-            status=AgileCard.IN_PROGRESS,
+            status=AgileCard.READY,
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
             content_item=content_item,
         )
         self.login(card.assignees.first())
+        card.start_project()
         self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -119,12 +119,11 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
             project_submission_type=ContentItem.LINK, template_repo=None
         )
         card = factories.AgileCardFactory(
-            status=AgileCard.READY,
+            status=AgileCard.IN_PROGRESS,
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
             content_item=content_item,
         )
         self.login(actor_user)
-        card.start_project()
         self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"
@@ -153,12 +152,11 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
             project_submission_type=ContentItem.LINK, template_repo=None
         )
         card = factories.AgileCardFactory(
-            status=AgileCard.READY,
+            status=AgileCard.IN_PROGRESS,
             recruit_project=factories.RecruitProjectFactory(content_item=content_item),
             content_item=content_item,
         )
         self.login(card.assignees.first())
-        card.start_project()
         self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"

--- a/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
+++ b/backend/curriculum_tracking/tests/test_activity_log_entry_creators_envoked.py
@@ -29,12 +29,13 @@ class log_card_started_Tests(APITestCase, APITestCaseMixin):
 
         start_url = f"{self.get_instance_url(card.id)}start_project/"
         response = self.client.post(start_url)
-        assert response.status_code == 200, response.data
+        self.assertEqual(response.status_code, 200)
+        
 
         card.refresh_from_db()
 
         # sanity check
-        assert card.assignees.count() == 1
+        self.assertEqual(card.assignees.count(), 1)
 
         self.assertEqual(LogEntry.objects.count(), 1)
         entry = LogEntry.objects.first()
@@ -88,7 +89,7 @@ class log_project_competence_review_done_Tests(APITestCase, APITestCaseMixin):
         response = self.client.post(
             start_url, data={"status": COMPETENT, "comments": "weee"}
         )
-        assert response.status_code == 200, response.data
+        self.assertEqual(response.status_code, 200)
 
         card.refresh_from_db()
 
@@ -109,11 +110,11 @@ class log_project_competence_review_done_Tests(APITestCase, APITestCaseMixin):
 
 
 class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
-    LIST_URL_NAME = "agilecard-list"  #based on class of api-viewset
+    LIST_URL_NAME = "agilecard-list"  
     SUPPRESS_TEST_POST_TO_CREATE = True
     SUPPRESS_TEST_GET_LIST = True
 
-    def test_review_requested(self):
+    def test_review_requested_authorised_user(self):
         actor_user = UserFactory(is_superuser=True, is_staff=True)
         content_item=factories.ProjectContentItemFactory(
                 project_submission_type=ContentItem.LINK, template_repo=None
@@ -126,25 +127,89 @@ class log_card_review_requested_Tests(APITestCase, APITestCaseMixin):
             content_item=content_item
             
         )
-        self.login(actor_user) #do we not login first before starting project?
-        card.start_project() #means card is now IP
+        self.login(actor_user) 
+        card.start_project() 
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
         request_review_url = f"{self.get_instance_url(card.id)}request_review/"
         response = self.client.post(request_review_url)
-        assert response.status_code == 200, response.data
+        
+        self.assertEqual(response.status_code, 200)
 
         card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
 
         # sanity check
-        assert card.assignees.count() == 1
+        self.assertEqual(card.assignees.count(), 1)
+        
 
         self.assertEqual(LogEntry.objects.count(), 1)
         entry = LogEntry.objects.first()
 
-        self.assertEqual(entry.actor_user, actor_user) #person who pushed review request button
-        self.assertEqual(entry.effected_user, card.assignees.first()) #person whose card it is
+        self.assertEqual(entry.actor_user, actor_user) 
+        self.assertEqual(entry.effected_user, card.assignees.first()) 
         self.assertEqual(entry.object_1, card.recruit_project)
         self.assertEqual(entry.object_2, None)
         self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
+        
+
+    def test_review_requested_assignee(self):
+        
+        content_item=factories.ProjectContentItemFactory(
+                project_submission_type=ContentItem.LINK, template_repo=None
+            )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY, 
+
+            
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item
+            
+        )
+        self.login(card.assignees.first()) 
+        card.start_project() 
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+        
+        self.assertEqual(response.status_code, 200)
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
+
+        # sanity check
+        self.assertEqual(card.assignees.count(), 1)
+        
+
+        self.assertEqual(LogEntry.objects.count(), 1)
+        entry = LogEntry.objects.first()
+
+        self.assertEqual(entry.actor_user, card.assignees.first()) 
+        self.assertEqual(entry.effected_user, card.assignees.first()) 
+        self.assertEqual(entry.object_1, card.recruit_project)
+        self.assertEqual(entry.object_2, None)
+        self.assertEqual(entry.event_type.name, creators.CARD_REVIEW_REQUESTED)
+
+
+    def test_review_requested_non_authorised_user(self):
+        actor_user = UserFactory(is_superuser=False)
+        content_item=factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.IN_PROGRESS, 
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item
+            )
+        self.login(actor_user) 
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+    
+
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+        self.assertEqual(response.status_code, 403)
+        
+        
             
 

--- a/backend/curriculum_tracking/tests/test_api_views.py
+++ b/backend/curriculum_tracking/tests/test_api_views.py
@@ -67,6 +67,107 @@ class TopicProgressViewsetTests(APITestCase, APITestCaseMixin):
         return topic_progress
 
 
+class RequestReviewViewsetTests(APITestCase, APITestCaseMixin):
+    LIST_URL_NAME = "agilecard-list"
+    SUPPRESS_TEST_POST_TO_CREATE = True
+    SUPPRESS_TEST_GET_LIST = True
+    FIELDS_THAT_CAN_BE_FALSEY = [
+        "code_review_competent_since_last_review_request",
+        "code_review_excellent_since_last_review_request",
+        "code_review_red_flag_since_last_review_request",
+        "code_review_ny_competent_since_last_review_request",
+        "requires_cards",
+        "required_by_cards",
+        "project_submission_type_nice",
+        "topic_needs_review",
+        "topic_progress",
+        "due_time",
+        "complete_time",
+        "review_request_time",
+        "start_time",
+        "tag_names",
+        "can_start",
+        "can_force_start",
+        # "open_pr_count",
+    ]
+
+    def setUp(self):
+        self.content_item_test = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        self.card_1 = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(
+                content_item=self.content_item_test
+            ),
+            content_item=self.content_item_test,
+        )
+        self.card_2 = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(
+                content_item=self.content_item_test
+            ),
+            content_item=self.content_item_test,
+        )
+
+        self.card_1.start_project()
+        self.card_2.start_project()
+
+        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
+        self.assertEqual(self.card_2.status, AgileCard.IN_PROGRESS)
+
+    def test_request_review_permissions_non_superuser_staff(self):
+
+        staff_user = factories.UserFactory(is_superuser=False, is_staff=True)
+        self.login(staff_user)
+
+        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["detail"].code, "permission_denied")
+
+        self.card_1.refresh_from_db()
+        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
+
+    def test_request_review_permissions_non_assignee(self):
+
+        recruit_user_non_card_assignee = factories.UserFactory(
+            is_superuser=False, is_staff=False
+        )
+        self.login(recruit_user_non_card_assignee)
+        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["detail"].code, "permission_denied")
+
+        self.card_1.refresh_from_db()
+        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
+
+    def test_request_review_permissions_superuser(self):
+        superuser = factories.UserFactory(is_superuser=True, is_staff=False)
+        self.login(superuser)
+        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.card_1.refresh_from_db()
+        self.assertEqual(self.card_1.status, AgileCard.IN_REVIEW)
+
+    def test_request_review_permissions_assignee(self):
+
+        self.login(self.card_2.assignees.first())
+        request_review_url = f"{self.get_instance_url(self.card_2.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.card_2.refresh_from_db()
+        self.assertEqual(self.card_2.status, AgileCard.IN_REVIEW)
+
+
 class AgileCardViewsetTests(APITestCase, APITestCaseMixin):
     LIST_URL_NAME = "agilecard-list"
     SUPPRESS_TEST_POST_TO_CREATE = True
@@ -161,83 +262,6 @@ class AgileCardViewsetTests(APITestCase, APITestCaseMixin):
 
         progress.refresh_from_db()
         self.assertEqual(progress.due_time.strftime("%c"), due_time_2.strftime("%c"))
-
-    def setUp(self):
-        # breakpoint()
-        self.content_item_test = factories.ProjectContentItemFactory(
-            project_submission_type=ContentItem.LINK, template_repo=None
-        )
-        self.card_1 = factories.AgileCardFactory(
-            status=AgileCard.READY,
-            recruit_project=factories.RecruitProjectFactory(
-                content_item=self.content_item_test
-            ),
-            content_item=self.content_item_test,
-        )
-        self.card_2 = factories.AgileCardFactory(
-            status=AgileCard.READY,
-            recruit_project=factories.RecruitProjectFactory(
-                content_item=self.content_item_test
-            ),
-            content_item=self.content_item_test,
-        )
-
-        self.card_1.start_project()
-        self.card_2.start_project()
-
-        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
-        self.assertEqual(self.card_2.status, AgileCard.IN_PROGRESS)
-
-    def test_request_review_permissions_non_superuser_staff(self):
-
-        staff_user = factories.UserFactory(is_superuser=False, is_staff=True)
-        self.login(staff_user)
-
-        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
-        response = self.client.post(request_review_url)
-
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.data["detail"].code, "permission_denied")
-
-        self.card_1.refresh_from_db()
-        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
-
-    def test_request_review_permissions_non_assignee(self):
-
-        recruit_user_non_card_assignee = factories.UserFactory(
-            is_superuser=False, is_staff=False
-        )
-        self.login(recruit_user_non_card_assignee)
-        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
-        response = self.client.post(request_review_url)
-
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.data["detail"].code, "permission_denied")
-
-        self.card_1.refresh_from_db()
-        self.assertEqual(self.card_1.status, AgileCard.IN_PROGRESS)
-
-    def test_request_review_permissions_superuser(self):
-        superuser = factories.UserFactory(is_superuser=True, is_staff=False)
-        self.login(superuser)
-        request_review_url = f"{self.get_instance_url(self.card_1.id)}request_review/"
-        response = self.client.post(request_review_url)
-
-        self.assertEqual(response.status_code, 200)
-
-        self.card_1.refresh_from_db()
-        self.assertEqual(self.card_1.status, AgileCard.IN_REVIEW)
-
-    def test_request_review_permissions_assignee(self):
-
-        self.login(self.card_2.assignees.first())
-        request_review_url = f"{self.get_instance_url(self.card_2.id)}request_review/"
-        response = self.client.post(request_review_url)
-
-        self.assertEqual(response.status_code, 200)
-
-        self.card_2.refresh_from_db()
-        self.assertEqual(self.card_2.status, AgileCard.IN_REVIEW)
 
     def test_list_assignees_permissions_on_list(self):
 

--- a/backend/curriculum_tracking/tests/test_api_views.py
+++ b/backend/curriculum_tracking/tests/test_api_views.py
@@ -1,3 +1,4 @@
+# from backend.curriculum_tracking.models import AgileCard
 from git_real.tests.factories import PullRequestFactory
 from rest_framework.test import APITestCase
 from test_mixins import APITestCaseMixin
@@ -7,7 +8,12 @@ from . import factories
 from core.tests import factories as core_factories
 from django.utils.timezone import datetime
 from datetime import timedelta
-from curriculum_tracking.models import ContentItem, RecruitProjectReview
+from curriculum_tracking.models import (
+    ContentItem,
+    RecruitProjectReview,
+    AgileCard,
+    ContentItem,
+)
 from django.utils import timezone
 from taggit.models import Tag
 from curriculum_tracking.constants import (
@@ -155,6 +161,95 @@ class AgileCardViewsetTests(APITestCase, APITestCaseMixin):
 
         progress.refresh_from_db()
         self.assertEqual(progress.due_time.strftime("%c"), due_time_2.strftime("%c"))
+
+    def test_request_review_permissions(self):
+
+        # test using superuser
+        superuser = factories.UserFactory(is_superuser=True, is_staff=False)
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(superuser)
+        card.start_project()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
+
+        # test using the card's assignee
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(card.assignees.first())
+        card.start_project()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_REVIEW)
+
+        # test using non superuser staff
+        staff_user = factories.UserFactory(is_superuser=False, is_staff=True)
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(staff_user)
+        card.start_project()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["detail"].code, "permission_denied")
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+
+        # test using not the cards assignee
+        recruit_user_non_card_assignee = factories.UserFactory(
+            is_superuser=False, is_staff=False
+        )
+        content_item = factories.ProjectContentItemFactory(
+            project_submission_type=ContentItem.LINK, template_repo=None
+        )
+        card = factories.AgileCardFactory(
+            status=AgileCard.READY,
+            recruit_project=factories.RecruitProjectFactory(content_item=content_item),
+            content_item=content_item,
+        )
+        self.login(recruit_user_non_card_assignee)
+        card.start_project()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
+        request_review_url = f"{self.get_instance_url(card.id)}request_review/"
+        response = self.client.post(request_review_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["detail"].code, "permission_denied")
+
+        card.refresh_from_db()
+        self.assertEqual(card.status, AgileCard.IN_PROGRESS)
 
     def test_list_assignees_permissions_on_list(self):
 
@@ -374,7 +469,7 @@ class WorkshopAttendanceViewsetTests(APITestCase, APITestCaseMixin):
 
 class ReviewerTrustViewsetTests(APITestCase, APITestCaseMixin):
 
-    LIST_URL_NAME = 'reviewtrust-list'
+    LIST_URL_NAME = "reviewtrust-list"
     SUPPRESS_TEST_POST_TO_CREATE = True
 
     def verbose_instance_factory(self):
@@ -411,14 +506,17 @@ class ReviewerTrustViewsetTests(APITestCase, APITestCaseMixin):
             user=factories.UserFactory(is_superuser=False, is_staff=False)
         )
         self.login(review_trust_object.user)
-        response = self.client.get(f'{self.api_url}?user={review_trust_object.user.id}')
+        response = self.client.get(f"{self.api_url}?user={review_trust_object.user.id}")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data[0].get('content_item_title'), review_trust_object.content_item.title)
+        self.assertEqual(
+            response.data[0].get("content_item_title"),
+            review_trust_object.content_item.title,
+        )
 
 
 class BurndownSnapShotViewsetTests(APITestCase, APITestCaseMixin):
 
-    LIST_URL_NAME = 'burndownsnapshot-list'
+    LIST_URL_NAME = "burndownsnapshot-list"
     SUPPRESS_TEST_POST_TO_CREATE = True
 
     def verbose_instance_factory(self):
@@ -444,16 +542,20 @@ class BurndownSnapShotViewsetTests(APITestCase, APITestCaseMixin):
             user=UserFactory(is_superuser=False, is_staff=False)
         )
         self.login(burndown_snapshot_object.user)
-        response = self.client.get(f'{self.api_url}?user__id={burndown_snapshot_object.user.id}')
+        response = self.client.get(
+            f"{self.api_url}?user__id={burndown_snapshot_object.user.id}"
+        )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data[0].get('user'), burndown_snapshot_object.user.id)
+        self.assertEqual(response.data[0].get("user"), burndown_snapshot_object.user.id)
 
-    def test_team_members_can_view_burndown_snapshot_objects_of_fellow_team_members(self):
+    def test_team_members_can_view_burndown_snapshot_objects_of_fellow_team_members(
+        self,
+    ):
 
         for user in self.team1_users:
             self.login(user)
-            response = self.client.get(f'{self.api_url}?user__id={user.id}')
+            response = self.client.get(f"{self.api_url}?user__id={user.id}")
             self.assertEqual(response.status_code, 200)
 
     def test_team1_users_cannot_view_team2_burndown_snapshot_objects(self):
@@ -463,7 +565,7 @@ class BurndownSnapShotViewsetTests(APITestCase, APITestCaseMixin):
 
         for user in self.team1_users:
             self.login(user)
-            response = self.client.get(f'{self.api_url}?user__id={[user.id for user in team2_users]}')
+            response = self.client.get(
+                f"{self.api_url}?user__id={[user.id for user in team2_users]}"
+            )
             self.assertEqual(response.status_code, 403)
-
-


### PR DESCRIPTION
Related issues: [please specify]

## Description:

1) Wrote tests  to check if the activity logging on requesting a review on a card worked as it should, and amended the request_review function (in curriculum_tracking, AgileCardViewset) as needed.

2) From writing a test in test_activity_log_entry_creators_envoked.py that failed I then saw that in api_views.py (curriculum tracking) the request_review function (in the class AgileCardViewset) did not call log_creators (like the add_review function does).

3) Moved tests related to permissions to test_api_views and amended tests in test_activity_log_entry_creators_envoked to only the tests needed for the logging

4) Created new test class for tests related to review request permissions in test_api_views, and wrote a setUp function to avoid code repetition in the tests.



## Screenshots/videos



## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
