### PR TITLE
View content button visible when card has not started yet

### DIFF
--- a/frontend/src/components/pages/CardDetails/Presentation.jsx
+++ b/frontend/src/components/pages/CardDetails/Presentation.jsx
@@ -8,6 +8,8 @@ import {
   TableCell,
   Typography,
 } from "@material-ui/core";
+import CardButton from "../../widgets/CardButton";
+import ViewContentButton from "../../widgets/ViewContentButton";
 
 import { makeStyles } from "@material-ui/core/styles";
 import CardStatusChip from "../../widgets/CardStatusChip";
@@ -134,6 +136,16 @@ function CardBasicDetails({ card }) {
           </Paper>
         </Grid>
       </Grid>
+      {card.canStart === false && (
+        <CardButton
+          widget={
+            <ViewContentButton
+              contentUrl={card.contentItemUrl}
+              contentItemId={card.contentItem}
+            />
+          }
+        />
+      )}
     </React.Fragment>
   );
 }
@@ -151,7 +163,6 @@ export default ({
   showAddReviewButton,
   linkSubmission,
   formErrors,
-  repoUrl,
 }) => {
   const classes = useStyles();
 


### PR DESCRIPTION
Related issues: [#467 ]

## Description:

## Screenshots/videos

### Before: left and right
![Screenshot_2022-06-05_22-25-33(no-view-content)](https://user-images.githubusercontent.com/37469171/172069718-e2b539a2-e3b6-464b-b9ec-d2add09bec11.png)

### After: left and right. The solutions attempts to avoid duplicate buttons
![Screenshot_2022-06-05_22-26-49(with-view-content)](https://user-images.githubusercontent.com/37469171/172069737-b71c005f-484c-4b3c-9324-8b56642a4949.png)

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
