### PR TITLE
column headings centered

### DIFF
--- a/frontend/src/components/regions/AgileBoard/Presentation.jsx
+++ b/frontend/src/components/regions/AgileBoard/Presentation.jsx
@@ -24,9 +24,7 @@ const useStyles = makeStyles((theme) => ({
     overflowY: "scroll",
   },
   typography: {
-    margin: "auto",
-    position: "relative",
-    top: 4,
+    padding: "3%",
   },
 }));
 
@@ -40,6 +38,7 @@ export default function Presentation({
   loadMoreCards,
 }) {
   const classes = useStyles();
+
   return (
     <React.Fragment>
       <Grid container wrap="nowrap">

--- a/frontend/src/components/regions/AgileBoard/Presentation.jsx
+++ b/frontend/src/components/regions/AgileBoard/Presentation.jsx
@@ -14,9 +14,6 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       margin: theme.spacing(1),
       width: theme.spacing(35),
-      // height: theme.spacing(100),
-      // height: `calc(100% - ${0}px)`,
-      // height: "calc(100vh - 20rem)",
     },
   },
   paper: {
@@ -25,6 +22,11 @@ const useStyles = makeStyles((theme) => ({
   column: {
     height: "calc(100% - 2.5rem)",
     overflowY: "scroll",
+  },
+  typography: {
+    margin: "auto",
+    position: "relative",
+    top: 4,
   },
 }));
 
@@ -40,7 +42,6 @@ export default function Presentation({
   const classes = useStyles();
   return (
     <React.Fragment>
-      {/* <Typography>{user.email}</Typography> */}
       <Grid container wrap="nowrap">
         {board.map((column) => {
           return (
@@ -52,7 +53,11 @@ export default function Presentation({
                 key={column.label}
               >
                 <Paper elevation={3} className={classes.paper}>
-                  <Typography variant="h5" align="center">
+                  <Typography
+                    variant="h5"
+                    align="center"
+                    className={classes.typography}
+                  >
                     {column.label} ({column.totalCards})
                   </Typography>
                   <div


### PR DESCRIPTION
Related issues: [Clean up visual debt - Round 1: User board]
https://www.notion.so/The-Umuzi-Build-Engine-Tilde-Syllabus-9b8df1933b514e369c909d16730ad145?p=70e5bc33d9b04d0abd7524656505bbac&pm=s

## Description:

Currently, there is less space on top of a column name than on the bottom

## Screenshots/videos

![centering](https://user-images.githubusercontent.com/37469171/195186269-8da0aa21-08c7-4de3-ab9d-34a064910fe3.png)


## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
