### PR TITLE
Django admin: bulk deactivate users

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -3,10 +3,38 @@ from . import models
 from guardian.admin import GuardedModelAdmin
 from adminsortable2.admin import SortableInlineAdminMixin
 
+from django import forms
+
+# class UserSetInline(admin.TabularInline):
+#     model = models.User.groups.through
+#     raw_id_fields = ("user",)
+
+
+class UserSetForm(forms.ModelForm):
+    active = forms.BooleanField(required=False)
+
+    class Meta:
+        model = models.User.groups.through
+        fields = ["user", "active"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk:
+            self.fields["active"].initial = self.instance.user.active
+
+
+class UserSetFormSet(forms.BaseInlineFormSet):
+    def save_existing(self, form, instance, commit=True):
+        instance.user.active = form.cleaned_data.get("active")
+        instance.user.save()
+        return super().save_existing(form, instance, commit)
+
 
 class UserSetInline(admin.TabularInline):
     model = models.User.groups.through
     raw_id_fields = ("user",)
+    form = UserSetForm
+    formset = UserSetFormSet
 
 
 @admin.register(models.Team)

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -2,12 +2,7 @@ from django.contrib import admin
 from . import models
 from guardian.admin import GuardedModelAdmin
 from adminsortable2.admin import SortableInlineAdminMixin
-
 from django import forms
-
-# class UserSetInline(admin.TabularInline):
-#     model = models.User.groups.through
-#     raw_id_fields = ("user",)
 
 
 class UserSetForm(forms.ModelForm):

--- a/backend/curriculum_tracking/admin.py
+++ b/backend/curriculum_tracking/admin.py
@@ -163,6 +163,7 @@ class UserAdmin(BaseUserAdmin):
         "groups",
         # "user_permissions",
     )
+    list_per_page = 25
 
     actions = ["bulk_deactivate_users"]
 

--- a/backend/curriculum_tracking/admin.py
+++ b/backend/curriculum_tracking/admin.py
@@ -142,7 +142,6 @@ class UserAdmin(BaseUserAdmin):
     )
     list_display = ("email", "is_superuser", "active")
     list_filter = (
-        "groups",
         "is_superuser",
         "is_staff",
         "active",

--- a/backend/curriculum_tracking/admin.py
+++ b/backend/curriculum_tracking/admin.py
@@ -3,6 +3,7 @@ from . import models
 from core import models as core_models
 from adminsortable2.admin import SortableInlineAdminMixin
 from automarker import models as automarker_models
+from .helpers import deactivate_users
 
 
 class ContentItemAutoMarkerConfigAdmin(admin.TabularInline):
@@ -21,7 +22,6 @@ class ContentItemOrderPreAdmin(admin.TabularInline):
 
 @admin.register(models.ContentItem)
 class ContentItemAdmin(admin.ModelAdmin):
-
     inlines = (
         ContentItemOrderPostAdmin,
         ContentItemOrderPreAdmin,
@@ -68,7 +68,6 @@ class RecruitProjectAdmin(admin.ModelAdmin):
 
 @admin.register(models.AgileCard)
 class AgileCardAdmin(admin.ModelAdmin):
-
     list_display = [
         "order",
         "status",
@@ -141,7 +140,7 @@ class UserAdmin(BaseUserAdmin):
         # GroupInline,
         # RecruitProjectInline,
     )
-    list_display = ("email", "is_superuser")
+    list_display = ("email", "is_superuser", "active")
     list_filter = (
         "is_superuser",
         "is_staff",
@@ -164,6 +163,13 @@ class UserAdmin(BaseUserAdmin):
         "groups",
         # "user_permissions",
     )
+
+    actions = ["bulk_deactivate_users"]
+
+    def bulk_deactivate_users(modeladmin, request, users):
+        deactivate_users(users)
+
+    bulk_deactivate_users.short_description = "Deactivate selected users"
 
 
 admin.site.register(User, UserAdmin)

--- a/backend/curriculum_tracking/admin.py
+++ b/backend/curriculum_tracking/admin.py
@@ -142,6 +142,7 @@ class UserAdmin(BaseUserAdmin):
     )
     list_display = ("email", "is_superuser", "active")
     list_filter = (
+        "groups",
         "is_superuser",
         "is_staff",
         "active",

--- a/backend/curriculum_tracking/admin.py
+++ b/backend/curriculum_tracking/admin.py
@@ -3,7 +3,6 @@ from . import models
 from core import models as core_models
 from adminsortable2.admin import SortableInlineAdminMixin
 from automarker import models as automarker_models
-from .helpers import deactivate_users
 
 
 class ContentItemAutoMarkerConfigAdmin(admin.TabularInline):
@@ -163,12 +162,11 @@ class UserAdmin(BaseUserAdmin):
         "groups",
         # "user_permissions",
     )
-    list_per_page = 25
 
     actions = ["bulk_deactivate_users"]
 
-    def bulk_deactivate_users(modeladmin, request, users):
-        deactivate_users(users)
+    def bulk_deactivate_users(self, request, users):
+        users.update(active=False)
 
     bulk_deactivate_users.short_description = "Deactivate selected users"
 

--- a/backend/curriculum_tracking/helpers.py
+++ b/backend/curriculum_tracking/helpers.py
@@ -182,3 +182,7 @@ def agile_card_reviews_outstanding(user):
 def pull_request_reviews_outstanding(user):
     # TODO: only implement this once the github webhook is healthier
     return []
+
+
+def deactivate_users(users):
+    users.update(active=False)

--- a/backend/curriculum_tracking/helpers.py
+++ b/backend/curriculum_tracking/helpers.py
@@ -182,7 +182,3 @@ def agile_card_reviews_outstanding(user):
 def pull_request_reviews_outstanding(user):
     # TODO: only implement this once the github webhook is healthier
     return []
-
-
-def deactivate_users(users):
-    users.update(active=False)


### PR DESCRIPTION
Related issues: [please specify]

## Description:

Can bulk deactivate users from:
- user list page(`/admin/core/user/`)
- team details page(`/admin/core/team/272/change/`)

## Screenshots/videos

**Users list page** via actions with filter team filters(left side) and user search(top)
![image](https://github.com/Umuzi-org/Tilde/assets/54069197/a00a0bb5-0d58-4530-a851-868d4fc4881f)

**Team details page**
![image](https://github.com/Umuzi-org/Tilde/assets/54069197/7cfb699c-34f6-4ec6-b0b9-b4e28f4e8136)


## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested new or existing tests and made sure that they pass
