### PR TITLE
Added start_time to RecruitProject serializer

### DIFF
--- a/backend/curriculum_tracking/serializers.py
+++ b/backend/curriculum_tracking/serializers.py
@@ -18,6 +18,7 @@ class RecruitProjectSerializer(serializers.ModelSerializer):
             "id",
             "content_item",
             "due_time",
+            "start_time",
             "complete_time",
             "repository",
             "project_reviews",


### PR DESCRIPTION
Related issues: N/A

## Description:

Including `start_time` to Recruit Projects api fields as required by integrations in progress

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
