### PR TITLE
Object permissions button is missing from team view on the backend

### DIFF
--- a/backend/core/templates/admin/core/team_change_form.html
+++ b/backend/core/templates/admin/core/team_change_form.html
@@ -2,8 +2,9 @@
 {% load i18n admin_urls %}
 
 {% block object-tools-items %}
-    {{ block.super }}
     <li>
-        <a href="{% url 'bulk_add_users_to_team' original.pk %}" class="button">Bulk Add Users</a>
+        <a href="{% url 'bulk_add_users_to_team' original.pk %}" class="button">{% trans "Bulk Add Users" %}</a>
     </li>
+    <li><a href="{% url opts|admin_urlname:'permissions' original.pk|admin_urlquote %}" class="permissionslink">{% trans "Object permissions" %}</a></li>
+    {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
Related issues: [please specify]

## Description:

- Added object permissions button/link in team change form

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

Before:
![image](https://github.com/Umuzi-org/Tilde/assets/54069197/ec6cf076-7ff9-4739-9758-03f31c4b817f)

After:
![image](https://github.com/Umuzi-org/Tilde/assets/54069197/dd7ec4d6-71ac-4e91-9925-72acc08e9664)

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested new or existing tests and made sure that they pass
