### PR TITLE
Make "command description" DRY so it doesn't need to be rewritten in each language

### DIFF
--- a/automarker_2/automarker_app/lib/automarker_test_runner.py
+++ b/automarker_2/automarker_app/lib/automarker_test_runner.py
@@ -119,7 +119,8 @@ class _TestRunner:
             )
 
         self.assert_setup_empty()
-        self.assert_command_description_present()
+        if not hasattr(self, TAG_COMMAND_DESCRIPTION):
+            self.assert_command_description_present()
         self.assert_no_import_errors()
         if assert_no_errors:
             self.assert_no_errors()
@@ -175,7 +176,8 @@ class _TestRunner:
         self.results[self.test_file_name][self.test_name].append(
             {
                 "error_message": error_message,
-                "command_description": self.last_command_output.command_description
+                "command_description": self.command_description
+                or self.last_command_output.command_description
                 if self.last_command_output
                 else None,
                 "status": status,
@@ -186,6 +188,9 @@ class _TestRunner:
         assert self.last_command_output[
             TAG_COMMAND_DESCRIPTION
         ], f"expected command description to be present. There is something wrong with the automarker project configuration\n\nstderr={self.last_command_output.stderr}\n\nstdout={self.last_command_output.stdout}"
+
+    def register_command_description(self, command_description):
+        self.command_description = command_description
 
     def assert_setup_empty(self):
         assert self.last_command_output[TAG_SETUP] in (

--- a/automarker_2/automarker_app/lib/automarker_test_runner.py
+++ b/automarker_2/automarker_app/lib/automarker_test_runner.py
@@ -176,7 +176,7 @@ class _TestRunner:
         self.results[self.test_file_name][self.test_name].append(
             {
                 "error_message": error_message,
-                "command_description": self.command_description
+                "command_description": getattr(self, "command_description", None)
                 or self.last_command_output.command_description
                 if self.last_command_output
                 else None,


### PR DESCRIPTION
Related issues: N/A

## Description:

New automarker lib setup will require or allow configs to set command description within functional tests, no need for repeating it in adapters for each flavour :)

Example usage:
```diff
file: consume_github_api_186/functional_tests/test_get_pull_requests.py

def test_returns_empty_array_when_no_matching_prs(tester):
    command = get_pull_requests(
        owner="Umuzi-org",
        repo="ACN-syllabus",
        start_date="2022-12-25",
        end_date="2022-12-25",
    )
+   tester.register_command_description("Bla bla bla")
    tester.run_command(command)
```

## But...

Setting command description in adapters allowed us to describe how certain functions were called, according to what we expected from each language.

JS ex.

```javascript
console.log(
  `call getPullRequests with arguments ${JSON.stringify({
    owner,
    repo,
    startDate,
    endDate,
  })}`
);
```

Python ex.
```python
print(
    f"call get_pull_requests with arguments owner={owner}, repo={repo}, start_date={start_date}, end_date={end_date}"
)
```

`if..else` blocks won't look good here, still thinking of a cleaner way we can use, or is something like the following pseudo desc. acceptable?:

```python
tester.register_command_description(f"call 'get pull requests' with arguments owner = {...}")
```



## Screenshots/videos

N/A

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
