### PR TITLE
windows configuration

### DIFF
--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -20,12 +20,17 @@ from .constants import (
     STEP_STATUS_RED_FLAG,
 )
 import json
+import platform
 
 
 def get_all_file_paths(directory):
     for path, _, filenames in os.walk(directory):
         for filename in filenames:
             yield os.path.join(path, filename)
+
+
+def check_if_current_os_windows():
+    return platform.system() == "Windows"
 
 
 class Step:
@@ -626,7 +631,7 @@ class PythonCreateVirtualEnv(Step):
         if len(stderr):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
-            if os.name == "nt":
+            if check_if_current_os_windows():
                 python_executable_path = 'Scripts/python'
             else:
                 python_executable_path =  'bin/pip'
@@ -642,7 +647,7 @@ class PythonDoRequirementsTxtInstall(Step):
     name = "pip install requirements.txt"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        if os.name == "nt":
+        if check_if_current_os_windows():
             pip_executable_path =  'Scripts/pip'
         else:
             pip_executable_path = 'bin/pip'
@@ -681,7 +686,7 @@ class PythonRunPytests(Step):
     name = "run learner pytests"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        if os.name == "nt":
+        if check_if_current_os_windows():
             python_executable_path = f"{clone_dir_path}/automarker_venv/Scripts/python"
         else:
             python_executable_path = "automarker_venv/bin/python"

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -627,13 +627,11 @@ class PythonCreateVirtualEnv(Step):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
             if os.name == "nt":
-                command = (
-                    f"{clone_dir_path/'automarker_venv'/'Scripts'/'python'} -m pip install --upgrade pip"
-                )
+                python_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'python'
             else:
-                command = (
-                    f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install --upgrade pip"
-                )
+                python_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
+
+            command = f"{python_executable_path} -m pip install --upgrade pip"
             stdout, stderr = subprocess_run(command)
             if stderr:
                 breakpoint()
@@ -645,9 +643,11 @@ class PythonDoRequirementsTxtInstall(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            command = f"{clone_dir_path/'automarker_venv'/'Scripts'/'pip'} install -r {clone_dir_path/'requirements.txt'}"
+            python_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'pip'
         else:
-            command = f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install -r {clone_dir_path/'requirements.txt'}"
+            python_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
+
+        command = f"{python_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
         if len(stderr):
             if stderr.startswith("ERROR: Could not open requirements file"):
@@ -682,13 +682,11 @@ class PythonRunPytests(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            command = (
-                f"cd {clone_dir_path} && {clone_dir_path}/automarker_venv/Scripts/python -m pytest --tb=line"
-            )
+            python_executable_path = f"{clone_dir_path} && {clone_dir_path}/automarker_venv/Scripts/python"
         else:
-            command = (
-                f"cd {clone_dir_path} && automarker_venv/bin/python -m pytest --tb=line"
-            )
+            python_executable_path = f"{clone_dir_path} && automarker_venv/bin/python"
+
+        command = f"cd {python_executable_path} -m pytest --tb=line"
         stdout, stderr = subprocess_run(command)
         if re.search("=== no tests ran in .* ===", stdout):
             self.set_outcome(

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -627,11 +627,11 @@ class PythonCreateVirtualEnv(Step):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
             if os.name == "nt":
-                python_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'python'
+                python_executable_path = 'Scripts' / 'python'
             else:
-                python_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
+                python_executable_path =  'bin' / 'pip'
 
-            command = f"{python_executable_path} -m pip install --upgrade pip"
+            command = f"{clone_dir_path/'automarker_venv'/python_executable_path} -m pip install --upgrade pip"
             stdout, stderr = subprocess_run(command)
             if stderr:
                 breakpoint()
@@ -643,11 +643,11 @@ class PythonDoRequirementsTxtInstall(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            pip_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'pip'
+            pip_executable_path =  'Scripts' / 'pip'
         else:
-            pip_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
+            pip_executable_path = 'bin' / 'pip'
 
-        command = f"{pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
+        command = f"{clone_dir_path/'automarker_venv'/pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
         if len(stderr):
             if stderr.startswith("ERROR: Could not open requirements file"):

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -29,7 +29,7 @@ def get_all_file_paths(directory):
             yield os.path.join(path, filename)
 
 
-def check_if_current_os_windows():
+def is_current_os_windows():
     return platform.system() == "Windows"
 
 
@@ -631,12 +631,8 @@ class PythonCreateVirtualEnv(Step):
         if len(stderr):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
-            if check_if_current_os_windows():
-                python_executable_path = 'Scripts/python'
-            else:
-                python_executable_path =  'bin/pip'
-
-            command = f"{clone_dir_path/'automarker_venv'/python_executable_path} -m pip install --upgrade pip"
+            python_executable_path_virtual_env = 'Scripts/python' if is_current_os_windows() else 'bin/pip'
+            command = f"{clone_dir_path/'automarker_venv'/python_executable_path_virtual_env} -m pip install --upgrade pip"
             stdout, stderr = subprocess_run(command)
             if stderr:
                 breakpoint()
@@ -647,10 +643,7 @@ class PythonDoRequirementsTxtInstall(Step):
     name = "pip install requirements.txt"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        if check_if_current_os_windows():
-            pip_executable_path =  'Scripts/pip'
-        else:
-            pip_executable_path = 'bin/pip'
+        pip_executable_path = 'Scripts/pip' if is_current_os_windows() else 'bin/pip'
 
         command = f"{clone_dir_path/'automarker_venv'/pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
@@ -686,12 +679,9 @@ class PythonRunPytests(Step):
     name = "run learner pytests"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        if check_if_current_os_windows():
-            python_executable_path = f"{clone_dir_path}/automarker_venv/Scripts/python"
-        else:
-            python_executable_path = "automarker_venv/bin/python"
+        python_executable_path_tests = f"{clone_dir_path}/automarker_venv/Scripts/python" if is_current_os_windows() else "automarker_venv/bin/python"
 
-        command = f"cd {clone_dir_path} && {python_executable_path} -m pytest --tb=line"
+        command = f"cd {clone_dir_path} && {python_executable_path_tests} -m pytest --tb=line"
         stdout, stderr = subprocess_run(command)
         if re.search("=== no tests ran in .* ===", stdout):
             self.set_outcome(

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -32,6 +32,8 @@ def get_all_file_paths(directory):
 def is_current_os_windows():
     return platform.system() == "Windows"
 
+def get_python_executable_path():
+    return 'Scripts' if is_current_os_windows() else 'bin'
 
 class Step:
     name = "name not defined"
@@ -631,7 +633,7 @@ class PythonCreateVirtualEnv(Step):
         if len(stderr):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
-            python_executable_path_virtual_env = 'Scripts/python' if is_current_os_windows() else 'bin/pip'
+            python_executable_path_virtual_env = f'{get_python_executable_path()}/python' if is_current_os_windows() else f'{get_python_executable_path()}/pip'
             command = f"{clone_dir_path/'automarker_venv'/python_executable_path_virtual_env} -m pip install --upgrade pip"
             stdout, stderr = subprocess_run(command)
             if stderr:
@@ -643,7 +645,7 @@ class PythonDoRequirementsTxtInstall(Step):
     name = "pip install requirements.txt"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        pip_executable_path = 'Scripts/pip' if is_current_os_windows() else 'bin/pip'
+        pip_executable_path = f'{get_python_executable_path()}/pip'
 
         command = f"{clone_dir_path/'automarker_venv'/pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
@@ -679,7 +681,8 @@ class PythonRunPytests(Step):
     name = "run learner pytests"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        python_executable_path_tests = f"{clone_dir_path}/automarker_venv/Scripts/python" if is_current_os_windows() else "automarker_venv/bin/python"
+        python_executable_path = f"automarker_venv/{get_python_executable_path()}/python"
+        python_executable_path_tests = f"{clone_dir_path}/{python_executable_path}" if is_current_os_windows() else python_executable_path
 
         command = f"cd {clone_dir_path} && {python_executable_path_tests} -m pytest --tb=line"
         stdout, stderr = subprocess_run(command)

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -627,9 +627,9 @@ class PythonCreateVirtualEnv(Step):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
             if os.name == "nt":
-                python_executable_path = 'Scripts' / 'python'
+                python_executable_path = 'Scripts/python'
             else:
-                python_executable_path =  'bin' / 'pip'
+                python_executable_path =  'bin/pip'
 
             command = f"{clone_dir_path/'automarker_venv'/python_executable_path} -m pip install --upgrade pip"
             stdout, stderr = subprocess_run(command)
@@ -643,9 +643,9 @@ class PythonDoRequirementsTxtInstall(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            pip_executable_path =  'Scripts' / 'pip'
+            pip_executable_path =  'Scripts/pip'
         else:
-            pip_executable_path = 'bin' / 'pip'
+            pip_executable_path = 'bin/pip'
 
         command = f"{clone_dir_path/'automarker_venv'/pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -643,11 +643,11 @@ class PythonDoRequirementsTxtInstall(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            python_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'pip'
+            pip_executable_path = clone_dir_path / 'automarker_venv' / 'Scripts' / 'pip'
         else:
-            python_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
+            pip_executable_path = clone_dir_path / 'automarker_venv' / 'bin' / 'pip'
 
-        command = f"{python_executable_path} install -r {clone_dir_path/'requirements.txt'}"
+        command = f"{pip_executable_path} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
         if len(stderr):
             if stderr.startswith("ERROR: Could not open requirements file"):
@@ -682,11 +682,11 @@ class PythonRunPytests(Step):
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
         if os.name == "nt":
-            python_executable_path = f"{clone_dir_path} && {clone_dir_path}/automarker_venv/Scripts/python"
+            python_executable_path = f"{clone_dir_path}/automarker_venv/Scripts/python"
         else:
-            python_executable_path = f"{clone_dir_path} && automarker_venv/bin/python"
+            python_executable_path = "automarker_venv/bin/python"
 
-        command = f"cd {python_executable_path} -m pytest --tb=line"
+        command = f"cd {clone_dir_path} && {python_executable_path} -m pytest --tb=line"
         stdout, stderr = subprocess_run(command)
         if re.search("=== no tests ran in .* ===", stdout):
             self.set_outcome(

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -29,12 +29,8 @@ def get_all_file_paths(directory):
             yield os.path.join(path, filename)
 
 
-def is_current_os_windows():
-    return platform.system() == "Windows"
-
-
 def get_python_executable_path():
-    if is_current_os_windows():
+    if platform.system() == "Windows":
         return "Scripts/python"
     return "bin/python"
 
@@ -685,15 +681,7 @@ class PythonRunPytests(Step):
     name = "run learner pytests"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        python_executable_path_tests = (
-            f"{clone_dir_path}/{PYTHON_EXECUTABLE_PATH}"
-            if is_current_os_windows()
-            else PYTHON_EXECUTABLE_PATH
-        )
-
-        command = (
-            f"cd {clone_dir_path} && {python_executable_path_tests} -m pytest --tb=line"
-        )
+        command = f"cd {clone_dir_path} && {clone_dir_path/'automarker_venv'/PYTHON_EXECUTABLE_PATH} -m pytest {clone_dir_path}/tests --tb=line"
         stdout, stderr = subprocess_run(command)
         if re.search("=== no tests ran in .* ===", stdout):
             self.set_outcome(

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -626,9 +626,14 @@ class PythonCreateVirtualEnv(Step):
         if len(stderr):
             self.set_outcome(STEP_STATUS_ERROR, message=stderr)
         else:
-            command = (
-                f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install --upgrade pip"
-            )
+            if os.name == "nt":
+                command = (
+                    f"{clone_dir_path/'automarker_venv'/'Scripts'/'python'} -m pip install --upgrade pip"
+                )
+            else:
+                command = (
+                    f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install --upgrade pip"
+                )
             stdout, stderr = subprocess_run(command)
             if stderr:
                 breakpoint()
@@ -639,7 +644,10 @@ class PythonDoRequirementsTxtInstall(Step):
     name = "pip install requirements.txt"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        command = f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install -r {clone_dir_path/'requirements.txt'}"
+        if os.name == "nt":
+            command = f"{clone_dir_path/'automarker_venv'/'Scripts'/'pip'} install -r {clone_dir_path/'requirements.txt'}"
+        else:
+            command = f"{clone_dir_path/'automarker_venv'/'bin'/'pip'} install -r {clone_dir_path/'requirements.txt'}"
         stdout, stderr = subprocess_run(command)
         if len(stderr):
             if stderr.startswith("ERROR: Could not open requirements file"):
@@ -673,11 +681,15 @@ class PythonRunPytests(Step):
     name = "run learner pytests"
 
     def run(self, project_uri, clone_dir_path, self_test, config, fail_fast):
-        command = (
-            f"cd {clone_dir_path} && automarker_venv/bin/python -m pytest --tb=line"
-        )
+        if os.name == "nt":
+            command = (
+                f"cd {clone_dir_path} && {clone_dir_path}/automarker_venv/Scripts/python -m pytest --tb=line"
+            )
+        else:
+            command = (
+                f"cd {clone_dir_path} && automarker_venv/bin/python -m pytest --tb=line"
+            )
         stdout, stderr = subprocess_run(command)
-
         if re.search("=== no tests ran in .* ===", stdout):
             self.set_outcome(
                 STEP_STATUS_RED_FLAG,


### PR DESCRIPTION
Related issues: The automarker wasnt running well on windows because the initial configuration was for unix(mac and linux) os

## Description:

I  updated the steps.py so that if the os that automarker is running on is Unix it uses the existing command and if the os is windows it uses command that is compatible for windows

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
