### PR TITLE
Add login_required decorator to user_passes_test_or_forbidden function

### DIFF
--- a/backend/frontend/tests/test_restricted_user_board_access.py
+++ b/backend/frontend/tests/test_restricted_user_board_access.py
@@ -122,6 +122,19 @@ class TestUserBoardAuthorization(FrontendTestMixin):
 
         self.assertIn("You don't have permission to access this page", body)
 
+    def test_login_redirection_if_unauthenticated(self):
+        """
+        Custom @user_passes_test_or_forbidden(func) should redirect to login if
+        the user is not authenticated.
+        """
+        url = self.reverse_url("user_board", kwargs={"user_id": self.viewed_user.id})
+
+        self.page.goto(url)
+
+        body = self.page.text_content("body")
+
+        self.assertIn("Log in", body)
+
     def test_user_with_manage_card_permission_can_view_user_board(self):
         self.do_login(self.user_with_manage_card_permission)
         url = self.reverse_url("user_board", kwargs={"user_id": self.viewed_user.id})

--- a/backend/frontend/views.py
+++ b/backend/frontend/views.py
@@ -85,6 +85,7 @@ def user_passes_test_or_forbidden(test_func):
     """
 
     def decorator(view_func):
+        @login_required()
         @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if test_func(request.user):


### PR DESCRIPTION
## Description:

If a user is logged in and they try to access a page they are not allowed to see then they are redirected to a "forbidden" page.

If the user is not logged in then they should get redirected to the login page.

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
