### PR TITLE
Fix: Frozen Modules Bug when marking pandas projects

### DIFF
--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -764,17 +764,18 @@ class PythonExecuteJupyterNotebooks(Step):
                 )
             else:
                 l = stderr.strip().split("\n")
-                if len(l) == 2:
-                    # It would look something like: ['[NbConvertApp] Converting notebook /home/sheena/workspace/Tilde/automarker_2/gitignore/247-python-perfect/notebooks/personality.ipynb to notebook', '[NbConvertApp] Writing 96572 bytes to /home/sheena/workspace/Tilde/automarker_2/gitignore/247-python-perfect/notebooks/personality.ipynb', ]
 
-                    if ("Converting notebook" not in l[0]) and ("Writing" not in l[1]):
-                        breakpoint()
-                        not_sure
+                start_line_prefix = "[NbConvertApp] Converting notebook"
+                end_line_prefix = "[NbConvertApp] Writing"
 
-                else:
+                start_line_present = any(
+                    line.startswith(start_line_prefix) for line in l
+                )
+                end_line_present = any(line.startswith(end_line_prefix) for line in l)
+
+                if not start_line_present or not end_line_present:
                     breakpoint()
-                    # not actually sure what would cause this...
-                    what
+                    not_sure
 
         self.set_outcome(STEP_STATUS_PASS)
 

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -765,6 +765,8 @@ class PythonExecuteJupyterNotebooks(Step):
             else:
                 l = stderr.strip().split("\n")
 
+                # It would look something like: ['[NbConvertApp] Converting notebook /home/sheena/workspace/Tilde/automarker_2/gitignore/247-python-perfect/notebooks/personality.ipynb to notebook', '[NbConvertApp] Writing 96572 bytes to /home/sheena/workspace/Tilde/automarker_2/gitignore/247-python-perfect/notebooks/personality.ipynb', ]
+
                 start_line_prefix = "[NbConvertApp] Converting notebook"
                 end_line_prefix = "[NbConvertApp] Writing"
 
@@ -773,6 +775,7 @@ class PythonExecuteJupyterNotebooks(Step):
                 )
                 end_line_present = any(line.startswith(end_line_prefix) for line in l)
 
+                # We check for these lines only because there may be some warnings in stderr.
                 if not start_line_present or not end_line_present:
                     breakpoint()
                     not_sure

--- a/automarker_2/automarker_app/lib/steps.py
+++ b/automarker_2/automarker_app/lib/steps.py
@@ -776,7 +776,7 @@ class PythonExecuteJupyterNotebooks(Step):
                 end_line_present = any(line.startswith(end_line_prefix) for line in l)
 
                 # We check for these lines only because there may be some warnings in stderr.
-                if not start_line_present or not end_line_present:
+                if not (start_line_present and end_line_present):
                     breakpoint()
                     not_sure
 


### PR DESCRIPTION
## Description:

﻿When marking or running a config check for jupyter notebook projects, a breakpoint is hit because [we expect a certain length of the output](https://github.com/Umuzi-org/Tilde/blob/60c050b0702eb9aef63e758ad973eea2dfcf041a/automarker_2/automarker_app/lib/steps.py#L767C2-L767C2) from the NbConvert cmd. This happens when Python prints out some warnings, as shown in the screenshot below.﻿﻿

﻿
![image](https://github.com/Umuzi-org/Tilde/assets/57295227/8a88c77e-b032-43f3-94d9-fc058952c7f3)



This fix only checks if the output we need is present in the output irregardless of the out. length


What are you up to? Fill us in :)

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
