### PR TITLE
Differentiate a blocked card from a ready card

### DIFF
--- a/backend/frontend/templates/frontend/user/board/partial_card.html
+++ b/backend/frontend/templates/frontend/user/board/partial_card.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 
 <div
-    class="mb-3 rounded-xl {% if card.request_user_is_assignee == False %}bg-orange-100{%else%}bg-blue-100{% endif %} {% if card.status == 'B' %}bg-slate-200{% endif %}"
+    class="mb-3 rounded-xl {% if card.request_user_is_assignee == False %}bg-orange-100{%else%}bg-blue-100{% endif %} {% if card.status == 'B' %}bg-zinc-200{% endif %}"
     id="card_{{ card.id }}" 
     data-status="{{card.status}}">
     <div class="border rounded-t-xl border-gray-300 py-2 px-4  flex justify-between items-center text-xs">

--- a/backend/frontend/templates/frontend/user/board/partial_card.html
+++ b/backend/frontend/templates/frontend/user/board/partial_card.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 
 <div
-    class="mb-3 rounded-xl {% if card.request_user_is_assignee == False %}bg-orange-100{%else%}bg-blue-100{% endif %}"
+    class="mb-3 rounded-xl {% if card.request_user_is_assignee == False %}bg-orange-100{%else%}bg-blue-100{% endif %} {% if card.status == 'B' %}bg-slate-200{% endif %}"
     id="card_{{ card.id }}" 
     data-status="{{card.status}}">
     <div class="border rounded-t-xl border-gray-300 py-2 px-4  flex justify-between items-center text-xs">


### PR DESCRIPTION
Related issues: [please specify]

## Description:

Mom link: [card_component: Make it clear when a card is blocked versus ready](https://umuzi-projects.monday.com/boards/1274815998/pulses/1301469421)

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

- I used the color `'grey'` to indicate that the card is a blocked-card.

![Screenshot 2024-01-16 164358](https://github.com/Umuzi-org/Tilde/assets/94048861/8c32ec7a-4074-4ece-9284-0007dc0a5371)


## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested new or existing tests and made sure that they pass
