### PR TITLE
Add timezone conversion to claim due timestamp

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -149,6 +149,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "threadlocal_middleware.ThreadLocalMiddleware",
     "logging_middleware.RequestUserLogMiddleware",
+    "timezone_middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = "backend.urls"

--- a/backend/frontend/static/frontend/utils.js
+++ b/backend/frontend/static/frontend/utils.js
@@ -5,3 +5,14 @@ function countLoadedPageItems(parentId) {
   const parent = document.getElementById(parentId);
   return parent.childElementCount - 1; // the button is an element too
 }
+
+/*
+  Detect user's timezone and store it in a cookie.
+*/
+(function () {
+  let tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (!tz) {
+    tz = "Africa/Johannesburg"
+  }
+  document.cookie = "tilde_tz=" + tz + ";path=/";
+})();

--- a/backend/frontend/templates/frontend/project_review_coordination/partial_claim.html
+++ b/backend/frontend/templates/frontend/project_review_coordination/partial_claim.html
@@ -1,4 +1,3 @@
-{% load tz %}
 <form>
 {% csrf_token %}
 <div
@@ -23,7 +22,7 @@ class="mb-3 p-2 rounded-xl border-2" id="claim-{{claim.id}}">
         <tr>
             <td>Due time</td>
             <td>
-                <span id="claim-{{claim.id}}-due">{{ claim.due_timestamp|timezone:"Africa/Johannesburg" }}</span> 
+                <span id="claim-{{claim.id}}-due">{{ claim.due_timestamp }}</span> 
                 <button 
                     class="{{styles.button_primary_small}}"
                     hx-post="{% url 'action_project_review_coordination_add_time' claim.id %}"

--- a/backend/frontend/templates/frontend/project_review_coordination/partial_claim.html
+++ b/backend/frontend/templates/frontend/project_review_coordination/partial_claim.html
@@ -1,3 +1,4 @@
+{% load tz %}
 <form>
 {% csrf_token %}
 <div
@@ -22,7 +23,7 @@ class="mb-3 p-2 rounded-xl border-2" id="claim-{{claim.id}}">
         <tr>
             <td>Due time</td>
             <td>
-                <span id="claim-{{claim.id}}-due">{{ claim.due_timestamp }}</span> 
+                <span id="claim-{{claim.id}}-due">{{ claim.due_timestamp|timezone:"Africa/Johannesburg" }}</span> 
                 <button 
                     class="{{styles.button_primary_small}}"
                     hx-post="{% url 'action_project_review_coordination_add_time' claim.id %}"

--- a/backend/timezone_middleware.py
+++ b/backend/timezone_middleware.py
@@ -1,0 +1,14 @@
+import zoneinfo
+from django.utils import timezone
+
+class TimezoneMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user_tz = request.COOKIES.get("tilde_tz")
+        if user_tz:
+            timezone.activate(zoneinfo.ZoneInfo(user_tz))
+        else:
+            timezone.activate(zoneinfo.ZoneInfo("Africa/Johannesburg"))
+        return self.get_response(request)


### PR DESCRIPTION
Related issues: [please specify]

## Description:
Currently, due date on claims is show in UTC (the default).

What are you up to? Fill us in :)
This smol change will make SAST (Africa/Johannesburg) the display tz.

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested new or existing tests and made sure that they pass
