### PR TITLE
Test failure fix: Made sure to use the correct time, because timezone was changed to the south african(jhb) timezone instead of default one.

### DIFF
--- a/backend/frontend/tests/test_course_component_details_pages.py
+++ b/backend/frontend/tests/test_course_component_details_pages.py
@@ -65,8 +65,8 @@ class TestLinkProjectDetailsPage(FrontendTestMixin):
 
         self.assertIn("learner_1@umuzi.org", body)
         self.assertIn("In Progress", body)
-        self.assertIn("Feb. 12, 2024, 2:06 p.m.", body)
-        self.assertIn("Feb. 13, 2024, 2:06 p.m.", body)
+        self.assertIn("Feb. 12, 2024, 4:06 p.m.", body)
+        self.assertIn("Feb. 13, 2024, 4:06 p.m.", body)
         self.assertIn("learner_reviewer@umuzi.org", body)
         self.assertIn(
             self.recruit_project.content_url,

--- a/backend/frontend/tests/test_course_component_details_pages.py
+++ b/backend/frontend/tests/test_course_component_details_pages.py
@@ -11,6 +11,7 @@ from curriculum_tracking.tests.factories import (
     RecruitProjectFactory,
 )
 from curriculum_tracking.models import AgileCard, ContentItem
+from unittest.mock import patch
 
 
 class TestLinkProjectDetailsPage(FrontendTestMixin):
@@ -53,7 +54,11 @@ class TestLinkProjectDetailsPage(FrontendTestMixin):
             recruit_project=self.recruit_project,
         )
 
-    def test_link_project_page_displays_correct_details(self):
+    @patch("django.utils.timezone.get_current_timezone")
+    def test_link_project_page_displays_correct_details(
+        self, mock_get_current_timezone
+    ):
+        mock_get_current_timezone.return_value = timezone.utc
         self.make_ip_project_card(ContentItem.LINK)
 
         self.link_project_url = self.reverse_url(
@@ -65,8 +70,8 @@ class TestLinkProjectDetailsPage(FrontendTestMixin):
 
         self.assertIn("learner_1@umuzi.org", body)
         self.assertIn("In Progress", body)
-        self.assertIn("Feb. 12, 2024, 4:06 p.m.", body)
-        self.assertIn("Feb. 13, 2024, 4:06 p.m.", body)
+        self.assertIn("Feb. 12, 2024, 2:06 p.m.", body)
+        self.assertIn("Feb. 13, 2024, 2:06 p.m.", body)
         self.assertIn("learner_reviewer@umuzi.org", body)
         self.assertIn(
             self.recruit_project.content_url,


### PR DESCRIPTION
Related issues: Mom task: [New test failures: test_link_project_page_displays_correct_details](https://umuzi-projects.monday.com/boards/1274815998/pulses/1458534365)

## Description:

What are you up to? Fill us in :)

The test was not failing because the timezone used by the frontend app was recently changed by changes in this merged PR, [Linked Here](https://github.com/Umuzi-org/Tilde/pull/715)

If the timezone ever gets changed again, this test will fail again. I may need to change how I am testing if times are getting displayed altogether.

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested new or existing tests and made sure that they pass
