### PR TITLE
added the lines cause an error and my though pattern

### DIFF
--- a/backend/git_real/activity_log_creators.py
+++ b/backend/git_real/activity_log_creators.py
@@ -56,8 +56,8 @@ def log_pr_opened(pull_request):
 
     if match == None:
         LogEntry.objects.create(
-            actor_user=pull_request.user,
-            effected_user=pull_request.user,
+            actor_user=pull_request.repository.user,
+            effected_user=pull_request.repository.user,
             object_1=pull_request,
             event_type=event_type,
         )

--- a/backend/git_real/activity_log_creators.py
+++ b/backend/git_real/activity_log_creators.py
@@ -1,5 +1,6 @@
 from django.utils import timezone
 from activity_log.models import LogEntry, EventType
+from django.contrib.contenttypes.models import ContentType
 
 
 PR_MERGED = "PR_MERGED"
@@ -43,10 +44,12 @@ def log_pr_opened(pull_request):
 
     event_type, _ = EventType.objects.get_or_create(name=PR_OPENED)
 
+    content_type = ContentType.objects.get_for_model(pull_request)
     match = LogEntry.objects.filter(
         actor_user=pull_request.user,
         effected_user=pull_request.user,
-        object_1=pull_request,
+        object_1_content_type=content_type,
+        object_1_id=pull_request.pk,
         event_type=event_type,
         timestamp__gte=timezone.now() - timezone.timedelta(minutes=2),
     ).first()

--- a/backend/git_real/models.py
+++ b/backend/git_real/models.py
@@ -127,16 +127,32 @@ class PullRequest(models.Model, Mixins):
             repository=repo, number=number, defaults=defaults, overrides=defaults
         )
         
-        # check if pr_opened log for this pull request exists
-        ## if it does, check if the timestamps match
-        ### if they match, then no need to log
-        ### otherwise we need need to log pr_opened for same pull request with new timestamp
-        ## else log pr_opened
-        
-        
-        # But before we do any of the above steps, lets see if just logging will work
-        log_pr_opened(pull_request) # doing this here raises a GenericForeignKey error
+        log_pr_opened(pull_request) 
+
         return pull_request
+    
+    def get_activity_log_summary_data(self):
+        """This is used by the activityLog serializer"""
+        # Note: the import direction is wrong. We should not be importing fro curriculum_tracking here. This is technical debt
+        from curriculum_tracking.models import AgileCard, RecruitProject
+
+        repo = self.repository
+        project = RecruitProject.objects.filter(repository=repo).order_by("pk").last()
+        card_id = None
+        if project:
+            try:
+                card = project.agile_card
+                card_id = card.id
+            except AgileCard.DoesNotExist:
+                pass
+
+        return {
+            "recruit_project": project.id if project else None,
+            "card": card_id,
+            "title": project.content_item.title if project else None,
+            "flavour_names": project.flavour_names if project else None,
+        }
+
 
 
 class PullRequestReview(models.Model, Mixins):

--- a/backend/git_real/models.py
+++ b/backend/git_real/models.py
@@ -7,7 +7,7 @@ from git_real.helpers import (
     github_timestamp_int_to_tz_aware_datetime,
     get_user_from_github_name,
 )
-from .activity_log_creators import log_push_event
+from .activity_log_creators import log_push_event, log_pr_opened
 
 from django.core.exceptions import MultipleObjectsReturned
 
@@ -126,6 +126,16 @@ class PullRequest(models.Model, Mixins):
         pull_request, _ = cls.get_or_create_or_update(
             repository=repo, number=number, defaults=defaults, overrides=defaults
         )
+        
+        # check if pr_opened log for this pull request exists
+        ## if it does, check if the timestamps match
+        ### if they match, then no need to log
+        ### otherwise we need need to log pr_opened for same pull request with new timestamp
+        ## else log pr_opened
+        
+        
+        # But before we do any of the above steps, lets see if just logging will work
+        log_pr_opened(pull_request) # doing this here raises a GenericForeignKey error
         return pull_request
 
 

--- a/backend/git_real/tests/test_activity_log_creators.py
+++ b/backend/git_real/tests/test_activity_log_creators.py
@@ -73,8 +73,8 @@ class log_pr_reviewed_Tests(APITestCase):
         # pr = PullRequest.objects.first()
         pr_review = PullRequestReview.objects.first()
 
-        self.assertEqual(LogEntry.objects.count(), 1)
-        entry = LogEntry.objects.first()
+        self.assertEqual(LogEntry.objects.filter(event_type__name=creators.PR_REVIEWED).count(), 1)
+        entry = LogEntry.objects.filter(event_type__name=creators.PR_REVIEWED).first()
 
         self.assertEqual(entry.actor_user, social_profile.user)
         self.assertEqual(entry.effected_user, repo.user)

--- a/backend/git_real/tests/test_activity_log_creators.py
+++ b/backend/git_real/tests/test_activity_log_creators.py
@@ -2,7 +2,7 @@
 """
 
 from django.test import TestCase
-from .factories import PullRequestReviewFactory, RepositoryFactory, PullRequestReview, PushFactory, Push
+from .factories import PullRequestReviewFactory, RepositoryFactory, PullRequestReview, PushFactory, Push, PullRequest
 import git_real.activity_log_creators as creators
 from activity_log.models import LogEntry
 
@@ -17,6 +17,18 @@ import mock
 
 # from git_real.models import PullRequest, PullRequestReview, Push
 from social_auth.tests.factories import SocialProfileFactory
+
+class log_pr_opened_Tests(TestCase):
+    def test_pr_opened_gets_logged(self):
+        pass
+        # body, headers = get_body_and_headers("pr_opened")
+        # pull_request_data = body["pull_request"]
+        # repo = RepositoryFactory(full_name=body["repository"]["full_name"])
+    
+        # pr = PullRequest.create_or_update_from_github_api_data(repo,pull_request_data)
+
+        # self.assertEqual(LogEntry.objects.count(), 1)
+
 
 
 class log_pr_reviewed_created_Tests(TestCase):

--- a/backend/git_real/tests/test_activity_log_creators.py
+++ b/backend/git_real/tests/test_activity_log_creators.py
@@ -1,8 +1,9 @@
 """for each of the log entry creators in git_real.activity_log_entry_creators, make sure it is called when it should be and creates the correct log entries
 """
 
+from datetime import timedelta
 from django.test import TestCase
-from .factories import PullRequestReviewFactory, RepositoryFactory, PullRequestReview, PushFactory, Push, PullRequest
+from .factories import PullRequestReviewFactory, RepositoryFactory, PullRequestReview, PushFactory, Push, PullRequest,PullRequestFactory
 import git_real.activity_log_creators as creators
 from activity_log.models import LogEntry
 
@@ -18,17 +19,14 @@ import mock
 # from git_real.models import PullRequest, PullRequestReview, Push
 from social_auth.tests.factories import SocialProfileFactory
 
-class log_pr_opened_Tests(TestCase):
-    def test_pr_opened_gets_logged(self):
-        pass
-        # body, headers = get_body_and_headers("pr_opened")
-        # pull_request_data = body["pull_request"]
-        # repo = RepositoryFactory(full_name=body["repository"]["full_name"])
+class log_pr_opened_Tests(APITestCase):
+
+    def test_that_timestamp_properly_set(self):
+        pull_request = PullRequestFactory()
+        creators.log_pr_opened(pull_request)
+        self.assertAlmostEqual(LogEntry.objects.first().timestamp, pull_request.created_at,delta=timedelta(seconds=1))
+
     
-        # pr = PullRequest.create_or_update_from_github_api_data(repo,pull_request_data)
-
-        # self.assertEqual(LogEntry.objects.count(), 1)
-
 
 
 class log_pr_reviewed_created_Tests(TestCase):

--- a/backend/git_real/tests/test_activity_log_creators.py
+++ b/backend/git_real/tests/test_activity_log_creators.py
@@ -20,16 +20,42 @@ import mock
 from social_auth.tests.factories import SocialProfileFactory
 
 class log_pr_opened_Tests(APITestCase):
-
+    def tearDown(self):
+            PullRequest.objects.all().delete()
+            LogEntry.objects.all().delete()
     def test_that_timestamp_properly_set(self):
         pull_request = PullRequestFactory()
         creators.log_pr_opened(pull_request)
         self.assertAlmostEqual(LogEntry.objects.first().timestamp, pull_request.created_at,delta=timedelta(seconds=1))
 
-    
+    @mock.patch.object(IsWebhookSignatureOk, "has_permission")
+    def test_open_a_pr(self, has_permission):
+        has_permission.return_value = True
+
+        self.assertEqual(PullRequest.objects.all().count(), 0)   
+
+        url = reverse(views.github_webhook)  
+
+        body, headers = get_body_and_headers("pull_request_opened")
+        RepositoryFactory(full_name=body["repository"]["full_name"])
+        self.client.post(url, format="json", data=body, extra=headers)
+
+        self.assertEqual(PullRequest.objects.all().count(), 1)
+
+        pull_request = PullRequest.objects.first()
+
+        self.assertEqual(LogEntry.objects.count(), 1)
+        entry = LogEntry.objects.first()
+        self.assertEqual(entry.actor_user, pull_request.repository.user)
+        self.assertEqual(entry.effected_user, pull_request.repository.user)
+        self.assertEqual(entry.object_1, pull_request)
+        self.assertEqual(entry.event_type.name, creators.PR_OPENED)
 
 
 class log_pr_reviewed_created_Tests(TestCase):
+    def tearDown(self):
+            LogEntry.objects.all().delete()
+            PullRequest.objects.all().delete()
     def test_that_timestamp_properly_set(self):
         review = PullRequestReviewFactory()
         creators.log_pr_reviewed(review)
@@ -50,6 +76,9 @@ class log_pr_reviewed_created_Tests(TestCase):
 
 
 class log_pr_reviewed_Tests(APITestCase):
+    def tearDown(self):
+            LogEntry.objects.all().delete()
+            PullRequest.objects.all().delete()
     @mock.patch.object(IsWebhookSignatureOk, "has_permission")
     def test_adding_a_pr_review(self, has_permission):
         has_permission.return_value = True
@@ -84,6 +113,9 @@ class log_pr_reviewed_Tests(APITestCase):
 
 
 class log_push_event_Tests(APITestCase):
+    def tearDown(self):
+        LogEntry.objects.all().delete()
+        Push.objects.all().delete()
     def test_that_timestamp_properly_set(self):
         push = PushFactory()
         creators.log_push_event(push)


### PR DESCRIPTION
Related issues: [please specify]

## Description:

I am stuck on this. I think the main reason is because I don't understand what a generic foreign key is. I will take some time to find out what a generic foreign key is and how I can resolve this. 

- ### Here is the output of the failing test:
```
(venv) raymond@Umuzi-Lenovo-IdeaPad:~/umuzi/tilde2_stuff/auth_pages_layout/backend$ python manage.py test --pattern="test_activity_log_creators.py"
warning: GIT_REAL_WEBHOOK_SECRET not set!
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.[Tilde-backend] [2024-04-30 08:35:14] INFO [logging_middleware:21] anonomous [POST] /git_real/github_webhook
[Tilde-backend] [2024-04-30 08:35:14] ERROR [django.request:224] Internal Server Error: /git_real/github_webhook
Traceback (most recent call last):
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 179, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/decorators.py", line 50, in handler
    return func(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/views.py", line 32, in github_webhook
    pr = PullRequest.create_or_update_from_github_api_data(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/models.py", line 138, in create_or_update_from_github_api_data
    log_pr_opened(pull_request)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/activity_log_creators.py", line 46, in log_pr_opened
    match = LogEntry.objects.filter(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 942, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 962, in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 969, in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1358, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1377, in _add_q
    child_clause, needed_inner = self.build_filter(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1258, in build_filter
    lookups, parts, reffed_expression = self.solve_lookup_type(arg)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1084, in solve_lookup_type
    _, field, _, lookup_parts = self.names_to_path(lookup_splitted, self.get_meta())
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1459, in names_to_path
    raise FieldError(
django.core.exceptions.FieldError: Field 'object_1' does not generate an automatic reverse relation and therefore cannot be used for reverse querying. If it is a GenericForeignKey, consider adding a GenericRelation.
E..[Tilde-backend] [2024-04-30 08:35:14] INFO [logging_middleware:21] anonomous [POST] /git_real/github_webhook
..
======================================================================
ERROR: test_adding_a_pr_review (git_real.tests.test_activity_log_creators.log_pr_reviewed_Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/mock/mock.py", line 1452, in patched
    return func(*newargs, **newkeywargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/tests/test_activity_log_creators.py", line 70, in test_adding_a_pr_review
    self.client.post(url, format="json", data=body, extra=headers)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/test.py", line 295, in post
    response = super().post(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/test.py", line 209, in post
    return self.generic('POST', path, data, content_type, **extra)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/test.py", line 233, in generic
    return super().generic(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/test/client.py", line 470, in generic
    return self.request(**r)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/test.py", line 285, in request
    return super().request(**kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/test.py", line 237, in request
    request = super().request(**kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/test/client.py", line 716, in request
    self.check_exception(response)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/test/client.py", line 577, in check_exception
    raise exc_value
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 179, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/rest_framework/decorators.py", line 50, in handler
    return func(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/views.py", line 32, in github_webhook
    pr = PullRequest.create_or_update_from_github_api_data(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/models.py", line 138, in create_or_update_from_github_api_data
    log_pr_opened(pull_request)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/git_real/activity_log_creators.py", line 46, in log_pr_opened
    match = LogEntry.objects.filter(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 942, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 962, in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, *args, **kwargs)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/query.py", line 969, in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1358, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1377, in _add_q
    child_clause, needed_inner = self.build_filter(
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1258, in build_filter
    lookups, parts, reffed_expression = self.solve_lookup_type(arg)
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1084, in solve_lookup_type
    _, field, _, lookup_parts = self.names_to_path(lookup_splitted, self.get_meta())
  File "/home/raymond/umuzi/tilde2_stuff/auth_pages_layout/backend/venv/lib/python3.10/site-packages/django/db/models/sql/query.py", line 1459, in names_to_path
    raise FieldError(
django.core.exceptions.FieldError: Field 'object_1' does not generate an automatic reverse relation and therefore cannot be used for reverse querying. If it is a GenericForeignKey, consider adding a GenericRelation.

----------------------------------------------------------------------
Ran 6 tests in 0.324s

FAILED (errors=1)
Destroying test database for alias 'default'...
```

## Screenshots/videos

<!-- If there is a visual component to what you did, please save us time by adding a screenshot. You can even link to a video demonstrating your feature, that would be cool too -->

## I solemnly swear that:

- [x] My code follows the style guidelines of this project
- [x] I have merged the develop branch into my branch and fixed any merge conflicts
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested new or existing tests and made sure that they pass
